### PR TITLE
fix: cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ target_include_directories(
 )
 target_link_libraries(ponio INTERFACE project_options project_warnings)
 set_target_properties(ponio PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED YES CXX_EXTENSIONS NO)
+target_compile_features(ponio INTERFACE cxx_std_20)
 
 target_include_directories(ponio INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${INCLUDE_DIR}>"
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
@@ -121,13 +122,16 @@ set(PONIO_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/solver/include)
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 option(BUILD_TESTS "build the tests" OFF)
+option(BUILD_DEMOS "build the demos" OFF)
 option(BUILD_SAMURAI_DEMOS "build demos working with samurai" OFF)
 
 if (BUILD_TESTS)
     add_subdirectory(solver/test)
 endif()
 
-add_subdirectory(solver/demos)
+if (BUILD_DEMOS)
+  add_subdirectory(solver/demos)
+endif()
 
 # package the project
 package_project(

--- a/pixi.toml
+++ b/pixi.toml
@@ -19,7 +19,7 @@ configure = { cmd = [
 ] }
 configure_test = { cmd = "cmake . -G 'Ninja Multi-Config' -B ./build -DBUILD_TESTS=ON" }
 configure_test_samurai = { cmd = "cmake . -G 'Ninja Multi-Config' -B ./build -DBUILD_TESTS=ON -DBUILD_SAMURAI_DEMOS=ON" }
-configure_debug = { cmd = "cmake . -G 'Ninja Multi-Config' -B ./build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug" }
+configure_debug = { cmd = "cmake . -G 'Ninja Multi-Config' -B ./build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_DEMOS=ON" }
 build_ninja = { cmd = "cmake --build ./build --config Release" } # don't call this rule alone
 build = { depends_on = ["configure", "build_ninja"] }
 build_test = { depends_on = ["configure_test", "build_ninja"] }


### PR DESCRIPTION
## Description
- Add an option in `CMakeLists.txt` to remove the build of the demos.
- Export c++20 when ponio is installed and other projects use it.

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/ponio/blob/master/solver/doc/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
