### PR TITLE
feat: add adaptive time step for samurai and ROCK

### DIFF
--- a/ponio/examples/heat_samurai.cpp
+++ b/ponio/examples/heat_samurai.cpp
@@ -105,7 +105,7 @@ main( int argc, char** argv )
     };
     auto f = [&]( [[maybe_unused]] double t, auto&& u )
     {
-        samurai::make_bc<samurai::Neumann>( u, 0. );
+        samurai::make_bc<samurai::Neumann<1>>( u, 0. );
         samurai::update_ghost_mr( u );
         return f_t( t )( u );
     };
@@ -123,13 +123,13 @@ main( int argc, char** argv )
     // Range to iterate over solution
     // auto sol_range = ponio::make_solver_range( pb, ponio::runge_kutta::rkc_202(), un_ini, { 0., Tf }, dt );
     // auto sol_range = ponio::make_solver_range( pb, ponio::runge_kutta::dirk23(), un_ini, { 0., Tf }, dt );
-    auto sol_range = ponio::make_solver_range( pb, ponio::runge_kutta::rock::rock4<false>( eigmax_computer ), un_ini, { 0., Tf }, dt );
+    auto sol_range = ponio::make_solver_range( pb, ponio::runge_kutta::rock::rock4<true>( eigmax_computer ), un_ini, { 0., Tf }, dt );
 
     auto it_sol = sol_range.begin();
 
     // Prepare MR for solution on iterator
     auto MRadaptation = samurai::make_MRAdapt( it_sol->state );
-    samurai::make_bc<samurai::Neumann>( it_sol->state, 0. );
+    samurai::make_bc<samurai::Neumann<1>>( it_sol->state, 0. );
     MRadaptation( mr_epsilon, mr_regularity );
     samurai::update_ghost_mr( it_sol->state );
 

--- a/ponio/include/ponio/detail.hpp
+++ b/ponio/include/ponio/detail.hpp
@@ -184,4 +184,7 @@ namespace detail
     concept problem_jacobian = std::invocable<decltype( &Problem_t::df ), Problem_t, value_t, state_t>
                             || std::invocable<decltype( Problem_t::df ), value_t, state_t>;
 
+    template <typename state_t>
+    concept has_array_range = requires( state_t u ) { requires std::ranges::range<decltype( u.array() )>; };
+
 } // namespace detail

--- a/ponio/include/ponio/runge_kutta/rock.hpp
+++ b/ponio/include/ponio/runge_kutta/rock.hpp
@@ -12,6 +12,7 @@
 #include <string_view>
 #include <utility>
 
+#include "../detail.hpp"
 #include "../ponio_config.hpp"
 #include "../stage.hpp"
 
@@ -326,6 +327,15 @@ namespace ponio::runge_kutta::rock
                               / static_cast<value_t>( std::size( unp1 ) ) );
         }
 
+        // same with something which contains a range
+        template <typename state_t>
+            requires ::detail::has_array_range<state_t>
+        auto
+        error( state_t&& unp1, state_t&& un, state_t&& tmp )
+        {
+            return error( unp1.array(), un.array(), tmp.array() );
+        }
+
         /**
          * @brief iteration of ROCK2 method
          *
@@ -526,6 +536,15 @@ namespace ponio::runge_kutta::rock
                                       return sum + ::detail::power<2>( error( unp1_i, *it_tmp++ ) );
                                   } )
                               / static_cast<value_t>( std::size( unp1 ) ) );
+        }
+
+        // same with something which contains a range
+        template <typename state_t>
+            requires ::detail::has_array_range<state_t>
+        auto
+        error( state_t const& unp1, state_t const& tmp )
+        {
+            return error( unp1.array(), tmp.array() );
         }
 
         /**


### PR DESCRIPTION
<!-- Thank you for your contribution to ponio! -->
<!-- ༊彡 -->

<!-- Please check the following before submitting your PR -->
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [x] This new PR is documented.
- [x] This new PR is tested.

## Description
<!-- A clear and concise description of what you have done in this PR. -->
Add a concept to test if current state has a `array` member function which returns a range concept. Next, just use previous error function (for ranges) with `u.array()`.

## Related issue
<!-- List the issues solved by this PR, if any. -->

## How has this been tested?
<!-- Give the list of files used to test this new implementation. -->

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/ponio/blob/master/ponio/doc/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
