### PR TITLE
fix: remove first iteration with time_step equals to zero

### DIFF
--- a/ponio/include/ponio/solver.hpp
+++ b/ponio/include/ponio/solver.hpp
@@ -103,7 +103,7 @@ namespace ponio
             , meth( meth_ )
             , pb( pb_ )
             , t_span( t_span_ )
-            , it_next_time( std::begin( t_span ) )
+            , it_next_time( std::next( std::begin( t_span ) ) )
             , dt_reference( std::nullopt )
         {
         }


### PR DESCRIPTION
<!-- Thank you for your contribution to ponio! -->
<!-- ༊彡 -->

<!-- Please check the following before submitting your PR -->
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [x] This new PR is documented.
- [x] This new PR is tested.

## Description
<!-- A clear and concise description of what you have done in this PR. -->

## Related issue

First iteration with `ponio::time_iterator` is done with $\Delta t=0$.

## How has this been tested?
<!-- Give the list of files used to test this new implementation. -->
Examples with `ponio::solver_range`

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/ponio/blob/master/ponio/doc/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
