### PR TITLE
fix: remove warning and error of compilation with NonLinearLocalSolvers

### DIFF
--- a/ponio/include/ponio/samurai_linear_algebra.hpp
+++ b/ponio/include/ponio/samurai_linear_algebra.hpp
@@ -18,6 +18,8 @@
 
 namespace ponio::linear_algebra
 {
+    template <typename solver_t>
+    concept has_Snes_method = std::is_member_function_pointer_v<decltype( &solver_t::Snes )>;
 
     template <class mesh_t, class value_t, std::size_t size, bool SOA>
     struct operator_algebra<::samurai::Field<mesh_t, value_t, size, SOA>>
@@ -36,7 +38,7 @@ namespace ponio::linear_algebra
             auto solver = samurai::petsc::make_solver( op );
             solver.solve( u, rhs );
 
-            if constexpr ( operator_t::cfg_t::scheme_type == samurai::SchemeType::NonLinear )
+            if constexpr ( operator_t::cfg_t::scheme_type == samurai::SchemeType::NonLinear && has_Snes_method<decltype( solver )> )
             {
                 int i_n_eval = 0;
                 SNESGetNumberFunctionEvals( solver.Snes(), &i_n_eval );

--- a/ponio/test/test_samurai.hxx
+++ b/ponio/test/test_samurai.hxx
@@ -46,7 +46,7 @@ static_for( lambda_t&& f )
 TEST_CASE( "samurai::order::pirock" )
 {
     int argc                = 1;
-    std::vector<char*> argv = { "ponio_tests" };
+    std::vector<char*> argv = { (char*)"ponio_tests" };
     char** argv_c           = argv.data();
 
     PetscInitialize( &argc, &argv_c, 0, nullptr );


### PR DESCRIPTION
<!-- Thank you for your contribution to ponio! -->
<!-- ༊彡 -->

<!-- Please check the following before submitting your PR -->
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [x] This new PR is documented.
- [x] This new PR is tested.

## Description
<!-- A clear and concise description of what you have done in this PR. -->

## Related issue
<!-- List the issues solved by this PR, if any. -->

Error on compilation with `samurai::LocalCellSchemeConfig<samurai::SchemeType::NonLinear, ...>` because this class doesn't expose a `Snes()` member function (to access to PETSc SNES solver and count number of evaluation of non-linear function). Add a test to check (with concept) if the solver exposes the SNES PETSc solver.

## How has this been tested?
<!-- Give the list of files used to test this new implementation. -->

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/ponio/blob/master/ponio/doc/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
