### PR TITLE
fix: change iteration_info interface on algorithms

### DIFF
--- a/.cppcheck
+++ b/.cppcheck
@@ -12,5 +12,5 @@ unusedFunction:ponio/include/ponio/problem.hpp:115
 unusedFunction:ponio/include/ponio/problem.hpp:154 # implicit_problem<Callable_t, Jacobian_t> make_implicit_problem( Callable_t&& f, Jacobian_t&& df )
 unusedFunction:ponio/include/ponio/runge_kutta/exprk.hpp:28 # auto coefficient_eval( func_t&& f, linear_t&& l )
 unusedFunction:ponio/include/ponio/runge_kutta/exprk.hpp:43 # auto triangular_get( tuple_t& t )
-unusedFunction:ponio/include/ponio/splitting/strang.hpp:336 # auto make_adaptive_strang_tuple( value_t delta, value_t tolerance, std::pair<Algorithms_t, value_t>&&... args )
+unusedFunction:ponio/include/ponio/splitting/strang.hpp:368 # auto make_adaptive_strang_tuple( value_t delta, value_t tolerance, std::pair<Algorithms_t, value_t>&&... args )
 ctuOneDefinitionRuleViolation:ponio/examples/heat.cpp

--- a/.github/workflows/ponio-ci.yml
+++ b/.github/workflows/ponio-ci.yml
@@ -57,14 +57,14 @@ jobs:
             package: "gcc-12 g++-12"
             cc: "gcc-12"
             cxx: "g++-12"
-          - cpp-version: clang-12
-            package: "clang-12"
-            cc: "clang-12"
-            cxx: "clang++-12"
-          - cpp-version: clang-13
-            package: "clang-13"
-            cc: "clang-13"
-            cxx: "clang++-13"
+          - cpp-version: gcc-13
+            package: "gcc-13 g++-13"
+            cc: "gcc-13"
+            cxx: "g++-13"
+          - cpp-version: gcc-14
+            package: "gcc-14 g++-14"
+            cc: "gcc-14"
+            cxx: "g++-14"
           - cpp-version: clang-14
             package: "clang-14"
             cc: "clang-14"
@@ -73,11 +73,29 @@ jobs:
             package: "clang-15"
             cc: "clang-15"
             cxx: "clang++-15"
+          - cpp-version: clang-16
+            package: "clang-16"
+            cc: "clang-16"
+            cxx: "clang++-16"
+          - cpp-version: clang-17
+            package: "clang-17"
+            cc: "clang-17"
+            cxx: "clang++-17"
+          - cpp-version: clang-18
+            package: "clang-18"
+            cc: "clang-18"
+            cxx: "clang++-18"
     env:
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
     steps:
       - uses: actions/checkout@v4
+      - name: Remove GCC from runner image
+        shell: bash
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-noble.list
+          sudo apt-get update
+          sudo apt-get install -y --allow-downgrades libc6=2.39-0ubuntu8.3 libc6-dev=2.39-0ubuntu8.3 libstdc++6=14.2.0-4ubuntu2~24.04 libgcc-s1=14.2.0-4ubuntu2~24.04
       - name: install compiler
         run: |
           sudo apt update

--- a/.github/workflows/ponio-ci.yml
+++ b/.github/workflows/ponio-ci.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
       - uses: pre-commit/action@v3.0.1
   # run cppcheck
   cppcheck:

--- a/ponio/include/ponio/method.hpp
+++ b/ponio/include/ponio/method.hpp
@@ -136,18 +136,18 @@ namespace ponio
         std::tuple<value_t, state_t, value_t>
         _return( value_t tn, state_t const& un, value_t dt )
         {
-            alg.info.error = ::detail::error_estimate( un, kis[Algorithm_t::N_stages], kis[Algorithm_t::N_stages + 1] );
+            alg.info().error = ::detail::error_estimate( un, kis[Algorithm_t::N_stages], kis[Algorithm_t::N_stages + 1] );
 
-            value_t new_dt = 0.9 * std::pow( alg.info.tolerance / alg.info.error, 1. / static_cast<value_t>( Algorithm_t::order ) ) * dt;
-            new_dt         = std::min( std::max( 0.2 * dt, new_dt ), 5. * dt );
+            value_t new_dt = 0.9 * std::pow( alg.info().tolerance / alg.info().error, 1. / static_cast<value_t>( Algorithm_t::order ) ) * dt;
+            new_dt = std::min( std::max( 0.2 * dt, new_dt ), 5. * dt );
 
-            if ( alg.info.error > alg.info.tolerance )
+            if ( alg.info().error > alg.info().tolerance )
             {
-                alg.info.success = false;
+                alg.info().success = false;
                 return std::make_tuple( tn, un, new_dt );
             }
 
-            alg.info.success = true;
+            alg.info().success = true;
             return std::make_tuple( tn + dt, kis[Algorithm_t::N_stages], new_dt );
         }
 
@@ -157,7 +157,7 @@ namespace ponio
         auto&
         info()
         {
-            return alg.info;
+            return alg.info();
         }
 
         /**
@@ -166,7 +166,7 @@ namespace ponio
         auto const&
         info() const
         {
-            return alg.info;
+            return alg.info();
         }
 
         /**
@@ -224,7 +224,7 @@ namespace ponio
         auto&
         info()
         {
-            return alg.info;
+            return alg.info();
         }
 
         /**
@@ -233,7 +233,7 @@ namespace ponio
         auto const&
         info() const
         {
-            return alg.info;
+            return alg.info();
         }
 
         /**
@@ -291,7 +291,7 @@ namespace ponio
         auto&
         info()
         {
-            return alg.info;
+            return alg.info();
         }
 
         /**
@@ -300,7 +300,7 @@ namespace ponio
         auto const&
         info() const
         {
-            return alg.info;
+            return alg.info();
         }
 
         /**

--- a/ponio/include/ponio/runge_kutta/dirk.hpp
+++ b/ponio/include/ponio/runge_kutta/dirk.hpp
@@ -117,7 +117,7 @@ namespace ponio::runge_kutta::diagonal_implicit_runge_kutta
         {
             if constexpr ( I == 0 )
             {
-                info.reset_eval();
+                _info.reset_eval();
             }
 
             state_t ui = un;
@@ -128,7 +128,7 @@ namespace ponio::runge_kutta::diagonal_implicit_runge_kutta
             std::size_t n_eval = 0;
             ::ponio::linear_algebra::operator_algebra<state_t>::solve( op_i, ui, rhs, n_eval );
 
-            info.number_of_eval += n_eval + 1;
+            _info.number_of_eval += n_eval + 1;
 
             return pb.f( tn + butcher.c[I] * dt, ui );
         }
@@ -140,7 +140,7 @@ namespace ponio::runge_kutta::diagonal_implicit_runge_kutta
         {
             if constexpr ( I == 0 )
             {
-                info.reset_eval();
+                _info.reset_eval();
             }
 
             using matrix_t = decltype( pb.df( tn, un ) );
@@ -167,7 +167,7 @@ namespace ponio::runge_kutta::diagonal_implicit_runge_kutta
             // $$
             auto g = [&]( state_t const& k ) -> state_t
             {
-                info.number_of_eval += 1;
+                _info.number_of_eval += 1;
                 return k
                      - pb.f( tn + butcher.c[I] * dt, ::detail::tpl_inner_product<I>( butcher.A[I], Ki, un, dt ) + dt * butcher.A[I][I] * k );
             };
@@ -222,11 +222,23 @@ namespace ponio::runge_kutta::diagonal_implicit_runge_kutta
             return ::detail::tpl_inner_product<N_stages>( butcher.b2, Ki, un, dt );
         }
 
+        auto&
+        info()
+        {
+            return _info;
+        }
+
+        auto const&
+        info() const
+        {
+            return _info;
+        }
+
         double tol           = ponio::default_config::newton_tolerance;      // tolerance of Newton method
         std::size_t max_iter = ponio::default_config::newton_max_iterations; // max iterations of Newton method
 
         linear_algebra_t linalg;
-        iteration_info<tableau_t> info;
+        iteration_info<tableau_t> _info;
     };
 
     // ---- *helper* ----

--- a/ponio/include/ponio/runge_kutta/dirk.hpp
+++ b/ponio/include/ponio/runge_kutta/dirk.hpp
@@ -222,12 +222,18 @@ namespace ponio::runge_kutta::diagonal_implicit_runge_kutta
             return ::detail::tpl_inner_product<N_stages>( butcher.b2, Ki, un, dt );
         }
 
+        /**
+         * @brief gets `iteration_info` object
+         */
         auto&
         info()
         {
             return _info;
         }
 
+        /**
+         * @brief gets `iteration_info` object (constant version)
+         */
         auto const&
         info() const
         {

--- a/ponio/include/ponio/runge_kutta/erk.hpp
+++ b/ponio/include/ponio/runge_kutta/erk.hpp
@@ -32,9 +32,9 @@ namespace ponio::runge_kutta::explicit_runge_kutta
 
         explicit_runge_kutta( double tolerance = default_config::tol )
             : butcher()
-            , info( tolerance )
+            , _info( tolerance )
         {
-            info.number_of_eval = N_stages;
+            _info.number_of_eval = N_stages;
         }
 
         template <typename problem_t, typename state_t, typename array_ki_t, std::size_t I>
@@ -59,7 +59,19 @@ namespace ponio::runge_kutta::explicit_runge_kutta
             return ::detail::tpl_inner_product<N_stages>( butcher.b2, Ki, un, dt );
         }
 
-        iteration_info<tableau_t> info;
+        auto&
+        info()
+        {
+            return _info;
+        }
+
+        auto const&
+        info() const
+        {
+            return _info;
+        }
+
+        iteration_info<tableau_t> _info;
     };
 
 } // namespace ponio::runge_kutta::explicit_runge_kutta

--- a/ponio/include/ponio/runge_kutta/erk.hpp
+++ b/ponio/include/ponio/runge_kutta/erk.hpp
@@ -59,12 +59,18 @@ namespace ponio::runge_kutta::explicit_runge_kutta
             return ::detail::tpl_inner_product<N_stages>( butcher.b2, Ki, un, dt );
         }
 
+        /**
+         * @brief gets `iteration_info` object
+         */
         auto&
         info()
         {
             return _info;
         }
 
+        /**
+         * @brief gets `iteration_info` object (constant version)
+         */
         auto const&
         info() const
         {

--- a/ponio/include/ponio/runge_kutta/exprk.hpp
+++ b/ponio/include/ponio/runge_kutta/exprk.hpp
@@ -98,13 +98,13 @@ namespace ponio::runge_kutta::exponential_runge_kutta
 
         using value_t = typename tableau_t::value_t;
 
-        iteration_info<tableau_t> info;
+        iteration_info<tableau_t> _info;
 
         explicit_exp_rk_butcher( double tolerance = ponio::default_config::tol )
             : butcher()
-            , info( tolerance )
+            , _info( tolerance )
         {
-            info.number_of_eval = N_stages;
+            _info.number_of_eval = N_stages;
         }
 
         template <typename problem_t, typename state_t, typename value_t, typename array_ki_t, std::size_t i>
@@ -127,6 +127,18 @@ namespace ponio::runge_kutta::exponential_runge_kutta
         stage( Stage<N_stages + 1>, problem_t& pb, value_t, state_t& un, array_ki_t const& Ki, value_t dt )
         {
             return detail::tpl_inner_product_b<N_stages>( butcher.b2, Ki, un, pb.l, dt );
+        }
+
+        auto&
+        info()
+        {
+            return _info;
+        }
+
+        auto const&
+        info() const
+        {
+            return _info;
         }
     };
 

--- a/ponio/include/ponio/runge_kutta/exprk.hpp
+++ b/ponio/include/ponio/runge_kutta/exprk.hpp
@@ -129,12 +129,18 @@ namespace ponio::runge_kutta::exponential_runge_kutta
             return detail::tpl_inner_product_b<N_stages>( butcher.b2, Ki, un, pb.l, dt );
         }
 
+        /**
+         * @brief gets `iteration_info` object
+         */
         auto&
         info()
         {
             return _info;
         }
 
+        /**
+         * @brief gets `iteration_info` object (constant version)
+         */
         auto const&
         info() const
         {

--- a/ponio/include/ponio/runge_kutta/lrk.hpp
+++ b/ponio/include/ponio/runge_kutta/lrk.hpp
@@ -75,12 +75,18 @@ namespace ponio::runge_kutta::lawson_runge_kutta
             return m_exp( dt * pb.l ) * ::detail::tpl_inner_product<N_stages>( butcher.b2, Ki, un, dt );
         }
 
+        /**
+         * @brief gets `iteration_info` object
+         */
         auto&
         info()
         {
             return _info;
         }
 
+        /**
+         * @brief gets `iteration_info` object (constant version)
+         */
         auto const&
         info() const
         {

--- a/ponio/include/ponio/runge_kutta/lrk.hpp
+++ b/ponio/include/ponio/runge_kutta/lrk.hpp
@@ -41,12 +41,14 @@ namespace ponio::runge_kutta::lawson_runge_kutta
         static constexpr std::size_t order    = tableau_t::order;
         static constexpr std::string_view id  = tableau_t::id;
 
+        using value_t = typename tableau_t::value_t;
+
         explicit_runge_kutta( exp_t exp_, double tolerance = ponio::default_config::tol )
             : lawson_base<exp_t>( exp_ )
             , butcher()
-            , info( tolerance )
+            , _info( tolerance )
         {
-            info.number_of_eval = N_stages;
+            _info.number_of_eval = N_stages;
         }
 
         template <typename problem_t, typename state_t, typename value_t, typename array_ki_t, std::size_t i>
@@ -73,7 +75,19 @@ namespace ponio::runge_kutta::lawson_runge_kutta
             return m_exp( dt * pb.l ) * ::detail::tpl_inner_product<N_stages>( butcher.b2, Ki, un, dt );
         }
 
-        iteration_info<tableau_t> info;
+        auto&
+        info()
+        {
+            return _info;
+        }
+
+        auto const&
+        info() const
+        {
+            return _info;
+        }
+
+        iteration_info<tableau_t> _info;
     };
 
     /**

--- a/ponio/include/ponio/runge_kutta/pirock.hpp
+++ b/ponio/include/ponio/runge_kutta/pirock.hpp
@@ -461,12 +461,18 @@ namespace ponio::runge_kutta::pirock
             return { tn + dt, u_np1, dt };
         }
 
+        /**
+         * @brief gets `iteration_info` object
+         */
         auto&
         info()
         {
             return _info;
         }
 
+        /**
+         * @brief gets `iteration_info` object (constant version)
+         */
         auto const&
         info() const
         {
@@ -1065,12 +1071,18 @@ namespace ponio::runge_kutta::pirock
             return { tn + dt, u_np1, dt };
         }
 
+        /**
+         * @brief gets `iteration_info` object
+         */
         auto&
         info()
         {
             return _info;
         }
 
+        /**
+         * @brief gets `iteration_info` object (constant version)
+         */
         auto const&
         info() const
         {

--- a/ponio/include/ponio/runge_kutta/pirock.hpp
+++ b/ponio/include/ponio/runge_kutta/pirock.hpp
@@ -173,7 +173,7 @@ namespace ponio::runge_kutta::pirock
         shampine_trick_caller_t shampine_trick_caller;
         value_t tolerance;
 
-        iteration_info<pirock_impl> info;
+        iteration_info<pirock_impl> _info;
 
         /**
          * @brief Construct a new pirock impl object
@@ -225,7 +225,7 @@ namespace ponio::runge_kutta::pirock
                                || detail::problem_jacobian<decltype( pb.implicit_part ), value_t, state_t>,
                 "This kind of problem is not inversible in ponio" );
 
-            info.reset_eval();
+            _info.reset_eval();
 
             auto [mdeg, deg_index, start_index, n_eval] = degree_computer::compute_n_stages_optimal_degree( rock::rock_order::rock_2(),
                 eig_computer,
@@ -236,8 +236,8 @@ namespace ponio::runge_kutta::pirock
                 4 );
             std::size_t s                               = mdeg + 2;
 
-            info.number_of_stages  = s + l + 3;
-            info.number_of_eval[0] = n_eval + s + l + 4; // explicit evaluation
+            _info.number_of_stages  = s + l + 3;
+            _info.number_of_eval[0] = n_eval + s + l + 4; // explicit evaluation
 
             value_t const alpha = alpha_beta_computer.alpha( s, l );
             value_t const beta  = alpha_beta_computer.beta( s, l );
@@ -334,7 +334,7 @@ namespace ponio::runge_kutta::pirock
                     u_sm2pl + beta * dt * pb.explicit_part( tn, u_sp1 ) + ( 1. - 2. * gamma ) * dt * pb.implicit_part( tn, u_sp1 ) );
                 ::ponio::linear_algebra::operator_algebra<state_t>::solve( op_sp2, u_sp2, rhs_sp2, n_eval_sp2 );
 
-                info.number_of_eval[1] += n_eval_sp1 + n_eval_sp2 + 1;
+                _info.number_of_eval[1] += n_eval_sp1 + n_eval_sp2 + 1;
             }
             else
             {
@@ -343,7 +343,7 @@ namespace ponio::runge_kutta::pirock
                 auto identity = ::ponio::linear_algebra::linear_algebra<matrix_t>::identity( un );
                 auto g_sp1    = [&]( state_t const& u ) -> state_t
                 {
-                    info.number_of_eval[1] += 1;
+                    _info.number_of_eval[1] += 1;
                     return u - gamma * dt * pb.implicit_part.f( tn, u ) - u_sm2pl;
                 };
                 auto dg = [&]( state_t const& u ) -> matrix_t
@@ -359,8 +359,8 @@ namespace ponio::runge_kutta::pirock
 
                 auto g_sp2 = [&]( state_t const& u ) -> state_t
                 {
-                    info.number_of_eval[0] += 1;
-                    info.number_of_eval[1] += 2;
+                    _info.number_of_eval[0] += 1;
+                    _info.number_of_eval[1] += 2;
 
                     return u - gamma * dt * pb.implicit_part.f( tn, u )
                          - ( u_sm2pl + beta * dt * pb.explicit_part( tn, u_sp1 ) + ( 1. - 2. * gamma ) * dt * pb.implicit_part( tn, u_sp1 ) );
@@ -373,7 +373,7 @@ namespace ponio::runge_kutta::pirock
                     ponio::default_config::newton_max_iterations );
             }
 
-            info.number_of_eval[1] += 3;
+            _info.number_of_eval[1] += 3;
 
             auto& u_sp3 = U[8];
             u_sp3       = u_sm2pl + ( 1. - gamma ) * dt * pb.implicit_part( tn, u_sp1 );
@@ -405,7 +405,7 @@ namespace ponio::runge_kutta::pirock
                     auto& rhs_R = U[14];
                     auto& err_R = U[15];
 
-                    info.number_of_eval[1] += 2;
+                    _info.number_of_eval[1] += 2;
 
                     rhs_R = dt * ( pb.implicit_part( tn, u_sp1 ) - pb.implicit_part( tn, u_sp2 ) ) / 6.;
 
@@ -459,6 +459,18 @@ namespace ponio::runge_kutta::pirock
             }
 
             return { tn + dt, u_np1, dt };
+        }
+
+        auto&
+        info()
+        {
+            return _info;
+        }
+
+        auto const&
+        info() const
+        {
+            return _info;
         }
     };
 
@@ -657,7 +669,7 @@ namespace ponio::runge_kutta::pirock
         shampine_trick_caller_t shampine_trick_caller;
         value_t tolerance;
 
-        iteration_info<pirock_RDA_impl> info;
+        iteration_info<pirock_RDA_impl> _info;
 
         /**
          * @brief Construct a new pirock_RDA_impl object
@@ -729,7 +741,7 @@ namespace ponio::runge_kutta::pirock
                                || detail::problem_jacobian<std::tuple_element_t<reaction_op::value, decltype( pb.system )>, value_t, state_t>,
                 "This kind of problem is not inversible in ponio" );
 
-            info.reset_eval();
+            _info.reset_eval();
 
             auto [mdeg, deg_index, start_index, n_eval] = degree_computer::compute_n_stages_optimal_degree( rock::rock_order::rock_2(),
                 eig_computer,
@@ -740,8 +752,8 @@ namespace ponio::runge_kutta::pirock
                 4 );
             std::size_t s                               = mdeg + 2;
 
-            info.number_of_stages  = s + l + 5;
-            info.number_of_eval[0] = n_eval + s + l + 4; // explicit evaluation
+            _info.number_of_stages  = s + l + 5;
+            _info.number_of_eval[0] = n_eval + s + l + 4; // explicit evaluation
 
             value_t const alpha = alpha_beta_computer.alpha( s, l );
             value_t const beta  = alpha_beta_computer.beta( s, l );
@@ -854,7 +866,7 @@ namespace ponio::runge_kutta::pirock
 
                 ::ponio::linear_algebra::operator_algebra<state_t>::solve( op_sp2, u_sp2, rhs_sp2, n_eval_sp2 );
 
-                info.number_of_eval[1] += n_eval_sp1 + n_eval_sp2 + 1;
+                _info.number_of_eval[1] += n_eval_sp1 + n_eval_sp2 + 1;
             }
             else
             {
@@ -863,7 +875,7 @@ namespace ponio::runge_kutta::pirock
                 auto identity = ::ponio::linear_algebra::linear_algebra<matrix_t>::identity( un );
                 auto g_sp1    = [&]( state_t const& u ) -> state_t
                 {
-                    info.number_of_eval[1] += 1;
+                    _info.number_of_eval[1] += 1;
 
                     // u - \gamma \Delta t F_R(u) - u^{(s-2+\ell)}
                     return u - gamma * dt * pb( reaction_op(), tn, u ) - u_sm2pl;
@@ -885,8 +897,8 @@ namespace ponio::runge_kutta::pirock
 
                 auto g_sp2 = [&]( state_t const& u ) -> state_t
                 {
-                    info.number_of_eval[0] += 1;
-                    info.number_of_eval[1] += 2;
+                    _info.number_of_eval[0] += 1;
+                    _info.number_of_eval[1] += 2;
 
                     // u - \gamma \Delta t F_R(u) - (u^{(s-2+\ell)} + \beta \Delta t F_D(u^{(s+1)}) + \Delta t F_A(u^{(s+1)}) +
                     // (1-2\gamma)\Delta t F_R(u^{(s+1)}))
@@ -902,7 +914,7 @@ namespace ponio::runge_kutta::pirock
                     ponio::default_config::newton_max_iterations );
             }
 
-            info.number_of_eval[1] += 3;
+            _info.number_of_eval[1] += 3;
 
             // u^{(s+3)} = u^{(s-2+\ell)} + (1-2\gamma)\Delta t F_A(u^{(s+1)}) + (1-\gamma)\Delta t F_R(u^{(s+1)})
             auto& u_sp3 = U[9];
@@ -977,7 +989,7 @@ namespace ponio::runge_kutta::pirock
                     auto& err_R = U[18];
                     auto& err_A = U[19];
 
-                    info.number_of_eval[1] += 2;
+                    _info.number_of_eval[1] += 2;
 
                     rhs_R = dt * ( pb( reaction_op(), tn, u_sp1 ) - pb( reaction_op(), tn, u_sp2 ) ) / 6.;
 
@@ -1051,6 +1063,18 @@ namespace ponio::runge_kutta::pirock
             }
 
             return { tn + dt, u_np1, dt };
+        }
+
+        auto&
+        info()
+        {
+            return _info;
+        }
+
+        auto const&
+        info() const
+        {
+            return _info;
         }
     };
 

--- a/ponio/include/ponio/runge_kutta/rkc.hpp
+++ b/ponio/include/ponio/runge_kutta/rkc.hpp
@@ -10,6 +10,7 @@
 #include <string_view>
 
 #include "../detail.hpp"
+#include "../iteration_info.hpp"
 #include "../stage.hpp"
 
 namespace ponio::runge_kutta::chebyshev
@@ -116,7 +117,7 @@ namespace ponio::runge_kutta::chebyshev
      *  @tparam N_stages_ number of stages
      *  @tparam value_t type of coefficients
      */
-    template <std::size_t N_stages_, typename value_t = double>
+    template <std::size_t N_stages_, typename _value_t = double>
     struct explicit_rkc2
     {
         static_assert( N_stages_ > 1, "Number of stages should be at least 2 in eRKC2" );
@@ -124,9 +125,11 @@ namespace ponio::runge_kutta::chebyshev
         static constexpr std::size_t order    = 2;
         static constexpr std::string_view id  = "RKC2";
         static constexpr bool is_embedded     = false;
+        using value_t                         = _value_t;
 
         value_t w0;
         value_t w1;
+        iteration_info<explicit_rkc2> _info;
 
         /**
          * @brief computes \f$b_j = \f$ coefficients with following formula: \f$b_0=b_2\f$, \f$b_1=\frac{1}{\omega_0}\f$, \f$b_j =
@@ -157,7 +160,9 @@ namespace ponio::runge_kutta::chebyshev
         explicit_rkc2( value_t eps = 2. / 13. )
             : w0( 1. + eps / ( N_stages * N_stages ) )
             , w1( dT<N_stages>( w0 ) / ddT<N_stages>( w0 ) )
+            , _info()
         {
+            _info.number_of_eval = N_stages;
         }
 
         /**
@@ -258,6 +263,18 @@ namespace ponio::runge_kutta::chebyshev
             value_t g2t = -( 1. - b<1>( w0 ) * T<1>( w0 ) ) * m2t;
 
             return ( 1. - m2 - n2 ) * yn + m2 * Yi[1] + n2 * yn + m2t * dt * f( tn + c1 * dt, Yi[1] ) + g2t * dt * Yi[0];
+        }
+
+        auto&
+        info()
+        {
+            return _info;
+        }
+
+        auto const&
+        info() const
+        {
+            return _info;
         }
     };
 

--- a/ponio/include/ponio/runge_kutta/rkc.hpp
+++ b/ponio/include/ponio/runge_kutta/rkc.hpp
@@ -265,12 +265,18 @@ namespace ponio::runge_kutta::chebyshev
             return ( 1. - m2 - n2 ) * yn + m2 * Yi[1] + n2 * yn + m2t * dt * f( tn + c1 * dt, Yi[1] ) + g2t * dt * Yi[0];
         }
 
+        /**
+         * @brief gets `iteration_info` object
+         */
         auto&
         info()
         {
             return _info;
         }
 
+        /**
+         * @brief gets `iteration_info` object (constant version)
+         */
         auto const&
         info() const
         {

--- a/ponio/include/ponio/runge_kutta/rock.hpp
+++ b/ponio/include/ponio/runge_kutta/rock.hpp
@@ -768,12 +768,18 @@ namespace ponio::runge_kutta::rock
             }
         }
 
+        /**
+         * @brief gets `iteration_info` object
+         */
         auto&
         info()
         {
             return _info;
         }
 
+        /**
+         * @brief gets `iteration_info` object (constant version)
+         */
         auto const&
         info() const
         {

--- a/ponio/include/ponio/runge_kutta/rock.hpp
+++ b/ponio/include/ponio/runge_kutta/rock.hpp
@@ -324,7 +324,7 @@ namespace ponio::runge_kutta::rock
         value_t a_tol; // absolute tolerance
         value_t r_tol; // relative tolerance
 
-        iteration_info<rock2_impl> info;
+        iteration_info<rock2_impl> _info;
 
         eig_computer_t eig_computer;
 
@@ -410,15 +410,15 @@ namespace ponio::runge_kutta::rock
         std::tuple<value_t, state_t, value_t>
         operator()( problem_t& f, value_t& tn, state_t& un, array_ki_t& G, value_t& dt )
         {
-            info.reset_eval();
+            _info.reset_eval();
 
             auto [mdeg,
                 deg_index,
                 start_index,
                 n_eval] = degree_computer::compute_n_stages_optimal_degree( rock_order::rock_2(), eig_computer, f, tn, un, dt );
 
-            info.number_of_stages = mdeg + 2;
-            info.number_of_eval   = n_eval + mdeg + 2;
+            _info.number_of_stages = mdeg + 2;
+            _info.number_of_eval   = n_eval + mdeg + 2;
 
             auto& uj   = G[0];
             auto& ujm1 = G[1];
@@ -477,15 +477,15 @@ namespace ponio::runge_kutta::rock
 
                 uj = ujm1 + delta_t_1 * uj + tmp;
 
-                info.error   = error( uj, un, tmp );
-                info.success = info.error < 1.0;
-                info.number_of_eval += 1;
+                _info.error   = error( uj, un, tmp );
+                _info.success = _info.error < 1.0;
+                _info.number_of_eval += 1;
 
-                value_t fac    = std::min( 2.0, std::max( 0.5, std::sqrt( 1.0 / info.error ) ) );
+                value_t fac    = std::min( 2.0, std::max( 0.5, std::sqrt( 1.0 / _info.error ) ) );
                 value_t new_dt = 0.8 * fac * dt;
 
                 // accepted step
-                if ( info.success )
+                if ( _info.success )
                 {
                     return { tn + dt, uj, new_dt };
                 }
@@ -498,6 +498,18 @@ namespace ponio::runge_kutta::rock
 
                 return { tn + dt, uj, dt };
             }
+        }
+
+        auto&
+        info()
+        {
+            return _info;
+        }
+
+        auto const&
+        info() const
+        {
+            return _info;
         }
     };
 
@@ -552,7 +564,7 @@ namespace ponio::runge_kutta::rock
         value_t a_tol; // absolute tolerance
         value_t r_tol; // relative tolerance
 
-        iteration_info<rock4_impl> info;
+        iteration_info<rock4_impl> _info;
 
         eig_computer_t eig_computer;
 
@@ -634,15 +646,15 @@ namespace ponio::runge_kutta::rock
         std::tuple<value_t, state_t, value_t>
         operator()( problem_t& f, value_t& tn, state_t& un, array_ki_t& G, value_t& dt )
         {
-            info.reset_eval();
+            _info.reset_eval();
 
             auto [mdeg,
                 deg_index,
                 start_index,
                 n_eval] = degree_computer::compute_n_stages_optimal_degree( rock_order::rock_4(), eig_computer, f, tn, un, dt, 5 );
 
-            info.number_of_stages = mdeg + 4;
-            info.number_of_eval   = n_eval + mdeg + 4;
+            _info.number_of_stages = mdeg + 4;
+            _info.number_of_eval   = n_eval + mdeg + 4;
 
             auto& uj   = G[0];
             auto& ujm1 = G[1];
@@ -731,17 +743,17 @@ namespace ponio::runge_kutta::rock
 
                 tmp = bh_1 * ujm1 + bh_2 * ujm2 + bh_3 * ujm3 + bh_4 * tmp + bh_5 * f( t_jm2, uj );
 
-                info.error   = error( uj, tmp );
-                info.success = info.error < 1.0;
-                info.number_of_eval += 1; // one of two evaluations already count
+                _info.error   = error( uj, tmp );
+                _info.success = _info.error < 1.0;
+                _info.number_of_eval += 1; // one of two evaluations already count
 
-                value_t fac = std::pow( ( 1. / info.error ), 0.25 );
+                value_t fac = std::pow( ( 1. / _info.error ), 0.25 );
                 fac         = std::min( 5., std::max( 0.1, 0.8 * fac ) );
 
                 value_t new_dt = fac * dt;
 
                 // accepted step
-                if ( info.success )
+                if ( _info.success )
                 {
                     return { tn + dt, uj, new_dt };
                 }
@@ -754,6 +766,18 @@ namespace ponio::runge_kutta::rock
 
                 return { tn + dt, uj, dt };
             }
+        }
+
+        auto&
+        info()
+        {
+            return _info;
+        }
+
+        auto const&
+        info() const
+        {
+            return _info;
         }
     };
 

--- a/ponio/include/ponio/splitting/detail.hpp
+++ b/ponio/include/ponio/splitting/detail.hpp
@@ -42,7 +42,7 @@ namespace ponio::splitting::detail
                 current_dt = tf - current_time;
             }
 
-            info.number_of_eval[I] += std::get<I>( meth ).info().number_of_eval;
+            info.template increment<I>( std::get<I>( meth ).info().number_of_eval );
         }
         return ui;
     }

--- a/ponio/include/ponio/splitting/lie.hpp
+++ b/ponio/include/ponio/splitting/lie.hpp
@@ -85,28 +85,44 @@ namespace ponio::splitting::lie
         auto
         operator()( Problem_t& f, value_t tn, state_t const& un, value_t dt );
 
+        /**
+         * @brief gets `iteration_info` object
+         */
         auto&
         info()
         {
             return _info;
         }
 
+        /**
+         * @brief gets `iteration_info` object (constant version)
+         */
         auto const&
         info() const
         {
             return _info;
         }
 
+        /**
+         * @brief gets array of stages of the Ith method
+         *
+         * @tparam I index of step method
+         */
         template <std::size_t I>
         auto&
-        stages()
+        stages( std::integral_constant<std::size_t, I> )
         {
             return std::get<I>( methods ).stages();
         }
 
+        /**
+         * @brief gets array of stages of the Ith method (constant version)
+         *
+         * @tparam I index of step method
+         */
         template <std::size_t I>
         auto const&
-        stages() const
+        stages( std::integral_constant<std::size_t, I> ) const
         {
             return std::get<I>( methods ).stages();
         }

--- a/ponio/include/ponio/splitting/strang.hpp
+++ b/ponio/include/ponio/splitting/strang.hpp
@@ -92,28 +92,44 @@ namespace ponio::splitting::strang
         auto
         operator()( Problem_t& f, value_t tn, state_t const& un, value_t dt );
 
+        /**
+         * @brief gets `iteration_info` object
+         */
         auto&
         info()
         {
             return _info;
         }
 
+        /**
+         * @brief gets `iteration_info` object (constant version)
+         */
         auto const&
         info() const
         {
             return _info;
         }
 
+        /**
+         * @brief gets array of stages of the Ith method
+         *
+         * @tparam I index of step method
+         */
         template <std::size_t I>
         auto&
-        stages()
+        stages( std::integral_constant<std::size_t, I> )
         {
             return std::get<I>( methods ).stages();
         }
 
+        /**
+         * @brief gets array of stages of the Ith method (constant version)
+         *
+         * @tparam I index of step method
+         */
         template <std::size_t I>
         auto const&
-        stages() const
+        stages( std::integral_constant<std::size_t, I> ) const
         {
             return std::get<I>( methods ).stages();
         }
@@ -291,28 +307,44 @@ namespace ponio::splitting::strang
             return std::make_tuple( tn + dt, u_np1_ref, new_dt );
         }
 
+        /**
+         * @brief gets `iteration_info` object
+         */
         auto&
         info()
         {
             return _info;
         }
 
+        /**
+         * @brief gets `iteration_info` object (constant version)
+         */
         auto const&
         info() const
         {
             return _info;
         }
 
+        /**
+         * @brief gets array of stages of the Ith method
+         *
+         * @tparam I index of step method
+         */
         template <std::size_t I>
         auto&
-        stages()
+        stages( std::integral_constant<std::size_t, I> )
         {
             return std::get<I>( methods ).stages();
         }
 
+        /**
+         * @brief gets array of stages of the Ith method (constant version)
+         *
+         * @tparam I index of step method
+         */
         template <std::size_t I>
         auto const&
-        stages() const
+        stages( std::integral_constant<std::size_t, I> ) const
         {
             return std::get<I>( methods ).stages();
         }

--- a/ponio/test/iteration_info.hxx
+++ b/ponio/test/iteration_info.hxx
@@ -324,8 +324,8 @@ TEST_CASE( "number_of_eval::pirock" )
     while ( it_sol->time < t_span.back() )
     {
         ++it_sol;
-        cumulative_counter_ex += it_sol.info().number_of_eval[0];
-        cumulative_counter_im += it_sol.info().number_of_eval[1];
+        cumulative_counter_ex += std::get<0>( it_sol.info().number_of_eval );
+        cumulative_counter_im += std::get<1>( it_sol.info().number_of_eval );
     }
 
     CHECK( cumulative_counter_im == manual_counter_im );
@@ -384,8 +384,8 @@ TEST_CASE( "number_of_eval::splitting_lie" )
     while ( it_sol->time < t_span.back() )
     {
         ++it_sol;
-        cumulative_counter_1 += it_sol.info().number_of_eval[0];
-        cumulative_counter_2 += it_sol.info().number_of_eval[1];
+        cumulative_counter_1 += std::get<0>( it_sol.info().number_of_eval );
+        cumulative_counter_2 += std::get<1>( it_sol.info().number_of_eval );
     }
 
     CHECK( cumulative_counter_1 == manual_counter_1 );
@@ -425,8 +425,8 @@ TEST_CASE( "number_of_eval::splitting_strang" )
     while ( it_sol->time < t_span.back() )
     {
         ++it_sol;
-        cumulative_counter_1 += it_sol.info().number_of_eval[0];
-        cumulative_counter_2 += it_sol.info().number_of_eval[1];
+        cumulative_counter_1 += std::get<0>( it_sol.info().number_of_eval );
+        cumulative_counter_2 += std::get<1>( it_sol.info().number_of_eval );
     }
 
     CHECK( cumulative_counter_1 == manual_counter_1 );
@@ -471,8 +471,8 @@ TEST_CASE( "number_of_eval::splitting_adaptive_strang" )
     while ( it_sol->time < t_span.back() )
     {
         ++it_sol;
-        cumulative_counter_1 += it_sol.info().number_of_eval[0];
-        cumulative_counter_2 += it_sol.info().number_of_eval[1];
+        cumulative_counter_1 += std::get<0>( it_sol.info().number_of_eval );
+        cumulative_counter_2 += std::get<1>( it_sol.info().number_of_eval );
     }
 
     CHECK( cumulative_counter_1 == manual_counter_1 );


### PR DESCRIPTION
<!-- Thank you for your contribution to ponio! -->
<!-- ༊彡 -->

<!-- Please check the following before submitting your PR -->
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [x] This new PR is documented.
- [x] This new PR is tested.

## Description
<!-- A clear and concise description of what you have done in this PR. -->
A splitting method with at least an IMEX method or an other splitting method failed because of incrementation of number of evaluation of functions.

## Related issue
<!-- List the issues solved by this PR, if any. -->
Standardize interface of `interation_info` class with a method in algorithms (eRK, DIRK, etc.) and other methods (splitting, IMEX, etc.).
Add a `interation_info` for RKC.

## How has this been tested?
<!-- Give the list of files used to test this new implementation. -->

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/ponio/blob/master/ponio/doc/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
