### PR TITLE
style: move detail namespace into ponio namespace

### DIFF
--- a/ponio/doc/source/api/detail.rst
+++ b/ponio/doc/source/api/detail.rst
@@ -1,11 +1,11 @@
 Details
 =======
 
-.. doxygenfunction:: detail::init_fill_array(T && value)
+.. doxygenfunction:: ponio::detail::init_fill_array(T && value)
    :project: ponio
 
-.. doxygenfunction:: detail::tpl_inner_product
+.. doxygenfunction:: ponio::detail::tpl_inner_product
    :project: ponio
 
-.. doxygenfunction:: detail::power
+.. doxygenfunction:: ponio::detail::power
    :project: ponio

--- a/ponio/include/ponio/butcher_tableau.hpp
+++ b/ponio/include/ponio/butcher_tableau.hpp
@@ -101,7 +101,7 @@ namespace ponio::runge_kutta::butcher
             {
                 for ( std::size_t j = 0ul; j < Tableau::N_stages; ++j )
                 {
-                    partial_sum += detail::power<2>( Tableau::A[i][j] );
+                    partial_sum += ponio::detail::power<2>( Tableau::A[i][j] );
                 }
             }
 

--- a/ponio/include/ponio/detail.hpp
+++ b/ponio/include/ponio/detail.hpp
@@ -13,7 +13,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace detail
+namespace ponio::detail
 {
     template <typename state_t>
     auto
@@ -111,13 +111,13 @@ namespace detail
      *
      * @code{,cpp}
      *   int i = 42;
-     *   const std::array<int,8> arr = detail::init_fill_array<8>( i ); // all values of `arr` are `42`
+     *   const std::array<int,8> arr = ponio::detail::init_fill_array<8>( i ); // all values of `arr` are `42`
      * @endcode
      *
      * @details `value` can also be an invokable object that take an unsigned integer and return type stored in array `T`.
      *
      * @code{,cpp}
-     *   const std::array<int,8> arr = detail::init_fill_array<8>([](int i){ return i*i; }); // get {0,1,4,9,16,25,36,49}
+     *   const std::array<int,8> arr = ponio::detail::init_fill_array<8>([](int i){ return i*i; }); // get {0,1,4,9,16,25,36,49}
      * @endcode
      *
      */
@@ -167,7 +167,7 @@ namespace detail
      * @param args arguments of function `f`
      *
      * @code{,cpp}
-     *   const std::array<int,8> arr = detail::init_fill_array<3>([](int i){ return i*i; }, 2); // get {4,4,4}
+     *   const std::array<int,8> arr = ponio::detail::init_fill_array<3>([](int i){ return i*i; }, 2); // get {4,4,4}
      * @endcode
      */
     template <std::size_t N, typename Function_t, typename... Args>
@@ -228,4 +228,4 @@ namespace detail
     template <typename state_t>
     concept has_array_range = requires( state_t u ) { requires std::ranges::range<decltype( u.array() )>; };
 
-} // namespace detail
+} // namespace ponio::detail

--- a/ponio/include/ponio/iteration_info.hpp
+++ b/ponio/include/ponio/iteration_info.hpp
@@ -105,7 +105,7 @@ namespace ponio
             , success( true )
             , is_step( false )
             , number_of_stages( 0 )
-            , number_of_eval( ::detail::init_fill_array<tableaus_t::N_operators, std::size_t>( 0 ) )
+            , number_of_eval( detail::init_fill_array<tableaus_t::N_operators, std::size_t>( 0 ) )
             , tolerance( tol )
         {
         }
@@ -116,7 +116,7 @@ namespace ponio
             , success( true )
             , is_step( false )
             , number_of_stages( tableaus_t::N_stages )
-            , number_of_eval( ::detail::init_fill_array<tableaus_t::N_operators, std::size_t>( 0 ) )
+            , number_of_eval( detail::init_fill_array<tableaus_t::N_operators, std::size_t>( 0 ) )
             , tolerance( tol )
         {
         }

--- a/ponio/include/ponio/method.hpp
+++ b/ponio/include/ponio/method.hpp
@@ -58,7 +58,7 @@ namespace ponio
          */
         method( Algorithm_t const& alg_, state_t const& shadow_of_u0 )
             : alg( alg_ )
-            , kis( ::detail::init_fill_array<std::tuple_size<step_storage_t>::value>( shadow_of_u0 ) )
+            , kis( ::ponio::detail::init_fill_array<std::tuple_size<step_storage_t>::value>( shadow_of_u0 ) )
         {
         }
 
@@ -136,7 +136,7 @@ namespace ponio
         std::tuple<value_t, state_t, value_t>
         _return( value_t tn, state_t const& un, value_t dt )
         {
-            alg.info().error = ::detail::error_estimate( un, kis[Algorithm_t::N_stages], kis[Algorithm_t::N_stages + 1] );
+            alg.info().error = ::ponio::detail::error_estimate( un, kis[Algorithm_t::N_stages], kis[Algorithm_t::N_stages + 1] );
 
             value_t new_dt = 0.9 * std::pow( alg.info().tolerance / alg.info().error, 1. / static_cast<value_t>( Algorithm_t::order ) ) * dt;
             new_dt = std::min( std::max( 0.2 * dt, new_dt ), 5. * dt );
@@ -207,7 +207,7 @@ namespace ponio
 
         method( Algorithm_t const& alg_, state_t const& shadow_of_u0 )
             : alg( alg_ )
-            , kis( ::detail::init_fill_array<std::tuple_size<step_storage_t>::value>( shadow_of_u0 ) )
+            , kis( ::ponio::detail::init_fill_array<std::tuple_size<step_storage_t>::value>( shadow_of_u0 ) )
         {
         }
 

--- a/ponio/include/ponio/runge_kutta/dirk.hpp
+++ b/ponio/include/ponio/runge_kutta/dirk.hpp
@@ -123,7 +123,7 @@ namespace ponio::runge_kutta::diagonal_implicit_runge_kutta
             state_t ui = un;
             auto op_i  = ::ponio::linear_algebra::operator_algebra<state_t>::identity( un )
                       - dt * butcher.A[I][I] * pb.f_t( tn + butcher.c[I] * dt );
-            auto rhs = ::detail::tpl_inner_product<I>( butcher.A[I], Ki, un, dt );
+            auto rhs = detail::tpl_inner_product<I>( butcher.A[I], Ki, un, dt );
 
             std::size_t n_eval = 0;
             ::ponio::linear_algebra::operator_algebra<state_t>::solve( op_i, ui, rhs, n_eval );
@@ -169,14 +169,14 @@ namespace ponio::runge_kutta::diagonal_implicit_runge_kutta
             {
                 _info.number_of_eval += 1;
                 return k
-                     - pb.f( tn + butcher.c[I] * dt, ::detail::tpl_inner_product<I>( butcher.A[I], Ki, un, dt ) + dt * butcher.A[I][I] * k );
+                     - pb.f( tn + butcher.c[I] * dt, detail::tpl_inner_product<I>( butcher.A[I], Ki, un, dt ) + dt * butcher.A[I][I] * k );
             };
             auto dg = [&]( state_t const& k ) -> matrix_t
             {
                 return identity
                      - butcher.A[I][I] * dt
                            * pb.df( tn + butcher.c[I] * dt,
-                               ::detail::tpl_inner_product<I>( butcher.A[I], Ki, un, dt ) + dt * butcher.A[I][I] * k );
+                               detail::tpl_inner_product<I>( butcher.A[I], Ki, un, dt ) + dt * butcher.A[I][I] * k );
             };
 
             // call newton method
@@ -211,7 +211,7 @@ namespace ponio::runge_kutta::diagonal_implicit_runge_kutta
             // $$
             //   u^{n+1} = u^n + \Delta t \sum_{i} b_i k_i
             // $$
-            return ::detail::tpl_inner_product<N_stages>( butcher.b, Ki, un, dt );
+            return detail::tpl_inner_product<N_stages>( butcher.b, Ki, un, dt );
         }
 
         template <typename problem_t, typename state_t, typename array_ki_t, typename tab_t = tableau_t>
@@ -219,7 +219,7 @@ namespace ponio::runge_kutta::diagonal_implicit_runge_kutta
         state_t
         stage( Stage<N_stages + 1>, problem_t&, value_t, state_t& un, array_ki_t const& Ki, value_t dt )
         {
-            return ::detail::tpl_inner_product<N_stages>( butcher.b2, Ki, un, dt );
+            return detail::tpl_inner_product<N_stages>( butcher.b2, Ki, un, dt );
         }
 
         /**

--- a/ponio/include/ponio/runge_kutta/erk.hpp
+++ b/ponio/include/ponio/runge_kutta/erk.hpp
@@ -41,14 +41,14 @@ namespace ponio::runge_kutta::explicit_runge_kutta
         state_t
         stage( Stage<I>, problem_t& f, value_t tn, state_t& un, array_ki_t const& Ki, value_t dt )
         {
-            return f( tn + butcher.c[I] * dt, ::detail::tpl_inner_product<I>( butcher.A[I], Ki, un, dt ) );
+            return f( tn + butcher.c[I] * dt, detail::tpl_inner_product<I>( butcher.A[I], Ki, un, dt ) );
         }
 
         template <typename problem_t, typename state_t, typename array_ki_t>
         state_t
         stage( Stage<N_stages>, problem_t&, value_t, state_t& un, array_ki_t const& Ki, value_t dt )
         {
-            return ::detail::tpl_inner_product<N_stages>( butcher.b, Ki, un, dt );
+            return detail::tpl_inner_product<N_stages>( butcher.b, Ki, un, dt );
         }
 
         template <typename problem_t, typename state_t, typename array_ki_t, typename tab_t = tableau_t>
@@ -56,7 +56,7 @@ namespace ponio::runge_kutta::explicit_runge_kutta
         state_t
         stage( Stage<N_stages + 1>, problem_t&, value_t, state_t& un, array_ki_t const& Ki, value_t dt )
         {
-            return ::detail::tpl_inner_product<N_stages>( butcher.b2, Ki, un, dt );
+            return detail::tpl_inner_product<N_stages>( butcher.b2, Ki, un, dt );
         }
 
         /**

--- a/ponio/include/ponio/runge_kutta/lrk.hpp
+++ b/ponio/include/ponio/runge_kutta/lrk.hpp
@@ -57,14 +57,14 @@ namespace ponio::runge_kutta::lawson_runge_kutta
         {
             return m_exp( -butcher.c[i] * dt * pb.l )
                  * pb.n( tn + butcher.c[i] * dt,
-                     m_exp( butcher.c[i] * dt * pb.l ) * ::detail::tpl_inner_product<i>( butcher.A[i], Ki, un, dt ) );
+                     m_exp( butcher.c[i] * dt * pb.l ) * detail::tpl_inner_product<i>( butcher.A[i], Ki, un, dt ) );
         }
 
         template <typename problem_t, typename state_t, typename value_t, typename array_ki_t>
         state_t
         stage( Stage<N_stages>, problem_t& pb, value_t, state_t& un, array_ki_t const& Ki, value_t dt )
         {
-            return m_exp( dt * pb.l ) * ::detail::tpl_inner_product<N_stages>( butcher.b, Ki, un, dt );
+            return m_exp( dt * pb.l ) * detail::tpl_inner_product<N_stages>( butcher.b, Ki, un, dt );
         }
 
         template <typename problem_t, typename state_t, typename value_t, typename array_ki_t, typename tab_t = tableau_t>
@@ -72,7 +72,7 @@ namespace ponio::runge_kutta::lawson_runge_kutta
         state_t
         stage( Stage<N_stages + 1>, problem_t& pb, value_t, state_t& un, array_ki_t const& Ki, value_t dt )
         {
-            return m_exp( dt * pb.l ) * ::detail::tpl_inner_product<N_stages>( butcher.b2, Ki, un, dt );
+            return m_exp( dt * pb.l ) * detail::tpl_inner_product<N_stages>( butcher.b2, Ki, un, dt );
         }
 
         /**

--- a/ponio/include/ponio/runge_kutta/rkc.hpp
+++ b/ponio/include/ponio/runge_kutta/rkc.hpp
@@ -148,7 +148,7 @@ namespace ponio::runge_kutta::chebyshev
             }
             else
             {
-                return ddT<J>( x ) / ( ::detail::power<2>( dT<J>( x ) ) );
+                return ddT<J>( x ) / ( detail::power<2>( dT<J>( x ) ) );
             }
         }
 

--- a/ponio/include/ponio/runge_kutta/rock.hpp
+++ b/ponio/include/ponio/runge_kutta/rock.hpp
@@ -64,7 +64,7 @@ namespace ponio::runge_kutta::rock
                 0.,
                 []( auto sum, auto x )
                 {
-                    return sum + ::detail::power<2>( std::abs( x ) );
+                    return sum + ::ponio::detail::power<2>( std::abs( x ) );
                 } ) );
         }
 
@@ -380,14 +380,14 @@ namespace ponio::runge_kutta::rock
                                   0.,
                                   [&]( auto sum, auto unp1_i )
                                   {
-                                      return sum + ::detail::power<2>( error( unp1_i, *it_un++, *it_tmp++ ) );
+                                      return sum + ::ponio::detail::power<2>( error( unp1_i, *it_un++, *it_tmp++ ) );
                                   } )
                               / static_cast<value_t>( std::size( unp1 ) ) );
         }
 
         // same with something which contains a range
         template <typename state_t>
-            requires ::detail::has_array_range<state_t>
+            requires ::ponio::detail::has_array_range<state_t>
         auto
         error( state_t&& unp1, state_t&& un, state_t&& tmp )
         {
@@ -616,14 +616,14 @@ namespace ponio::runge_kutta::rock
                                   0.,
                                   [&]( auto sum, auto unp1_i )
                                   {
-                                      return sum + ::detail::power<2>( error( unp1_i, *it_tmp++ ) );
+                                      return sum + ::ponio::detail::power<2>( error( unp1_i, *it_tmp++ ) );
                                   } )
                               / static_cast<value_t>( std::size( unp1 ) ) );
         }
 
         // same with something which contains a range
         template <typename state_t>
-            requires ::detail::has_array_range<state_t>
+            requires ::ponio::detail::has_array_range<state_t>
         auto
         error( state_t const& unp1, state_t const& tmp )
         {

--- a/ponio/include/ponio/splitting/strang.hpp
+++ b/ponio/include/ponio/splitting/strang.hpp
@@ -291,7 +291,7 @@ namespace ponio::splitting::strang
             _call_inc( f, tn, u_np1_ref, dt, 0. );
             _call_inc( f, tn, u_np1_shift, dt, _info.delta );
 
-            _info.error = ::detail::error_estimate( un, u_np1_ref, u_np1_shift );
+            _info.error = ::ponio::detail::error_estimate( un, u_np1_ref, u_np1_shift );
 
             value_t new_dt = 0.9 * std::sqrt( _info.tolerance / _info.error ) * dt;
             new_dt         = std::min( std::max( 0.2 * dt, new_dt ), 5. * dt );

--- a/ponio/test/detail.hxx
+++ b/ponio/test/detail.hxx
@@ -8,9 +8,9 @@
 
 TEST_CASE( "detail::power" )
 {
-    CHECK( detail::power<2>( 16 ) == 256 );
-    CHECK( detail::power<2>( std::sqrt( 2. ) ) == doctest::Approx( 2.0 ).epsilon( 1e-15 ) );
-    CHECK( detail::power<10>( 2 ) == 1024 );
+    CHECK( ponio::detail::power<2>( 16 ) == 256 );
+    CHECK( ponio::detail::power<2>( std::sqrt( 2. ) ) == doctest::Approx( 2.0 ).epsilon( 1e-15 ) );
+    CHECK( ponio::detail::power<10>( 2 ) == 1024 );
 }
 
 TEST_CASE( "detail::init_fill_array" )
@@ -18,7 +18,7 @@ TEST_CASE( "detail::init_fill_array" )
     SUBCASE( "with a value" )
     {
         std::array<int, 5> const a1 = { 42, 42, 42, 42, 42 };
-        auto const a2               = detail::init_fill_array<5>( 42 );
+        auto const a2               = ponio::detail::init_fill_array<5>( 42 );
 
         REQUIRE( a1.size() == a2.size() );
         for ( auto i = 0u; i < a1.size(); ++i )
@@ -29,7 +29,7 @@ TEST_CASE( "detail::init_fill_array" )
     SUBCASE( "with a function" )
     {
         std::array<int, 5> const a1 = { 0, 1, 4, 9, 16 };
-        auto const a2               = detail::init_fill_array<5>(
+        auto const a2               = ponio::detail::init_fill_array<5>(
             [count = 0]( int i ) mutable
             {
                 auto tmp = i + count * count;
@@ -49,15 +49,15 @@ TEST_CASE( "detail::init_fill_array" )
 TEST_CASE( "detail::tpl_inner_product" )
 {
     constexpr std::size_t N          = 10;
-    std::array<int, N + 1> const tab = detail::init_fill_array<N + 1>(
+    std::array<int, N + 1> const tab = ponio::detail::init_fill_array<N + 1>(
         [count = 0]( int i ) mutable
         {
             return i + count++;
         },
         0 );
 
-    CHECK( detail::tpl_inner_product<N + 1>( tab, tab, 0, 1 ) == ( N * ( N + 1 ) * ( 2 * N + 1 ) / 6 ) );
+    CHECK( ponio::detail::tpl_inner_product<N + 1>( tab, tab, 0, 1 ) == ( N * ( N + 1 ) * ( 2 * N + 1 ) / 6 ) );
 
     constexpr std::size_t M = 5;
-    CHECK( detail::tpl_inner_product<M + 1>( tab, tab, 0, 1 ) == ( M * ( M + 1 ) * ( 2 * M + 1 ) / 6 ) );
+    CHECK( ponio::detail::tpl_inner_product<M + 1>( tab, tab, 0, 1 ) == ( M * ( M + 1 ) * ( 2 * M + 1 ) / 6 ) );
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to ponio! -->
<!-- ༊彡 -->

<!-- Please check the following before submitting your PR -->
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [x] This new PR is tested.

## Description
<!-- A clear and concise description of what you have done in this PR. -->
Move the `detail` namespace into `ponio`namespace.

## Related issue
<!-- List the issues solved by this PR, if any. -->
`detail::` namespace is in conflit with namespace of other library like boost::.

## How has this been tested?
<!-- Give the list of files used to test this new implementation. -->

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/ponio/blob/master/ponio/doc/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
