### PR TITLE
feat: add option to build ponio offline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,12 +94,19 @@ if (BUILD_DOC)
   set(DOC_ALGO_CMD -d -do ${DOC_ALGO_RST})
 endif()
 
+option(BUILD_OFFLINE "build offline (without references to methods)" OFF)
+set(BUILD_OFFLINE_OPT "")
+if(BUILD_OFFLINE)
+  set(BUILD_OFFLINE_OPT --offline)
+endif()
+
 add_custom_command(
     OUTPUT ${BUTCHER_METHODS} ${DOC_ALGO_RST}
     COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/ponio/code_generator.py ${json_files}
                 -o ${BUTCHER_METHODS}
                 --Ndigit=${Ndigit}
                 ${DOC_ALGO_CMD}
+                ${BUILD_OFFLINE_OPT}
     COMMENT "Generating code..."
     VERBATIM
 )

--- a/ponio/code_generator.py
+++ b/ponio/code_generator.py
@@ -322,11 +322,14 @@ parser.add_argument('-d', '--doc', required=False, action='store_true',
                     help="generate also Sphinx documentation (api/algorithm.rst file)")
 parser.add_argument('-do', '--doc-output', type=str, required=False,
                     help="Name of output RST file")
-parser.add_argument('--offline', required=False, action='store_false',
+parser.add_argument('--offline', required=False, action='store_true',
                     help="make an offline generation (without bibliography research in Doxygen comments)")
 
 if __name__ == '__main__':
     args = parser.parse_args()
+
+    if args.offline:
+        doi_bib = doi_bib_offline
 
     list_erk, list_exprk, list_dirk, list_irk = multisplit_list(
         4)(extract_method(args.FILE), tag_id)

--- a/ponio/code_generator.py
+++ b/ponio/code_generator.py
@@ -22,12 +22,15 @@ options:
 
 import sympy as sp
 import numpy as np
-import itertools
 
 import json
 import os
 import sys
 import argparse
+
+# type hints
+from typing import Any
+from collections.abc import Callable
 
 
 def phi(i, j=None, c=None):
@@ -68,13 +71,13 @@ def phi(i, j=None, c=None):
     )
 
 
-def is_lower_matrix(M: sp.Matrix):
+def is_lower_matrix(M: sp.Matrix) -> bool:
     return sum([
         sp.Abs(M[i, j]) for i, j in zip(*np.triu_indices(M.cols, 1))
     ]) == 0
 
 
-def is_strictly_lower_matrix(M: sp.Matrix):
+def is_strictly_lower_matrix(M: sp.Matrix) -> bool:
     return sum([
         sp.Abs(M[i, j]) for i, j in zip(*np.triu_indices(M.cols))
     ]) == 0
@@ -143,7 +146,7 @@ class multisplit_list:
     def __init__(self, n: int):
         self.n = n
 
-    def __call__(self, seq: list, condition):
+    def __call__(self, seq: list, condition: Callable[[Any], int]):
         r = [[] for _ in range(self.n)]
         for x in seq:
             r[condition(x)].append(x)
@@ -160,7 +163,10 @@ def tag_id(rk):
     return select[rk['tag']]
 
 
-def doi_bib(doi: str):
+def doi_bib_crossref(doi: str):
+    """
+        return bibliography reference from doi with a request to `api.crossref.org`
+    """
     import urllib.request
 
     with urllib.request.urlopen(f"https://api.crossref.org/works/{doi}") as response:
@@ -177,6 +183,20 @@ def doi_bib(doi: str):
         'url': message['URL'],
         'bib': f"{author}, *{title}*, {pubdate}, {publisher}"
     }
+
+
+def doi_bib_offline(doi: str):
+    """
+        return bibliography reference as doi and url to doi website
+    """
+    return {
+        'url': f'https://doi.org/{doi}',
+        'bib': doi
+    }
+
+
+# make a request to get bibliography by default
+doi_bib = doi_bib_crossref
 
 
 def expRK_code_skeleton(X: list, c: list):
@@ -298,9 +318,12 @@ parser.add_argument('-o', '--output', type=str,
                     help="Name of output file header C++")
 parser.add_argument('--Ndigit', type=int, default=36, required=False,
                     help="number of digit in output Butcher tableau [default: 36]")
-parser.add_argument('-d', '--doc', required=False, action='store_true')
+parser.add_argument('-d', '--doc', required=False, action='store_true',
+                    help="generate also Sphinx documentation (api/algorithm.rst file)")
 parser.add_argument('-do', '--doc-output', type=str, required=False,
                     help="Name of output RST file")
+parser.add_argument('--offline', required=False, action='store_false',
+                    help="make an offline generation (without bibliography research in Doxygen comments)")
 
 if __name__ == '__main__':
     args = parser.parse_args()


### PR DESCRIPTION
<!-- Thank you for your contribution to ponio! -->
<!-- ༊彡 -->

<!-- Please check the following before submitting your PR -->
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [x] This new PR is documented.
- [x] This new PR is tested.

## Description
<!-- A clear and concise description of what you have done in this PR. -->
Add an option `--offline` in `codegen.py` or `-DBUILD_OFFLINE=ON` with cmake to build ponio without request to get bibliography of doi.

## Related issue
<!-- List the issues solved by this PR, if any. -->

## How has this been tested?
<!-- Give the list of files used to test this new implementation. -->

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/ponio/blob/master/ponio/doc/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
