### PR TITLE
fix: remove const for samurai solver

### DIFF
--- a/ponio/include/ponio/linear_algebra.hpp
+++ b/ponio/include/ponio/linear_algebra.hpp
@@ -61,7 +61,7 @@ namespace ponio::linear_algebra
 
         template <typename operator_t, typename rhs_t>
         static void
-        solve( operator_t const& op, scalar_t& xn, rhs_t const& rhs )
+        solve( operator_t& op, scalar_t& xn, rhs_t const& rhs )
         {
             static constexpr std::size_t max_iter = 100;
             static constexpr scalar_t tol         = 1e-5;

--- a/ponio/include/ponio/samurai_linear_algebra.hpp
+++ b/ponio/include/ponio/samurai_linear_algebra.hpp
@@ -33,7 +33,7 @@ namespace ponio::linear_algebra
 
         template <typename operator_t, typename state_t, typename rhs_t>
         static void
-        solve( operator_t const& op, state_t& u, rhs_t& rhs, std::size_t& n_eval )
+        solve( operator_t& op, state_t& u, rhs_t& rhs, std::size_t& n_eval )
         {
             auto solver = samurai::petsc::make_solver( op );
             solver.solve( u, rhs );


### PR DESCRIPTION
<!-- Thank you for your contribution to ponio! -->
<!-- ༊彡 -->

<!-- Please check the following before submitting your PR -->
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [ ] This new PR is documented.
- [x] This new PR is tested.

## Description
<!-- A clear and concise description of what you have done in this PR. -->

Remove a `const` for operator given to `ponio::linear_algebra::operator_algebra::solver` function.

## Related issue
<!-- List the issues solved by this PR, if any. -->

## How has this been tested?
<!-- Give the list of files used to test this new implementation. -->

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/ponio/blob/master/ponio/doc/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
