### PR TITLE
[feat] improve adaptive Strang method with estimate of Lipschitz constant

### DIFF
--- a/ponio/include/ponio/runge_kutta/dirk.hpp
+++ b/ponio/include/ponio/runge_kutta/dirk.hpp
@@ -24,35 +24,12 @@
 
 namespace ponio::runge_kutta::diagonal_implicit_runge_kutta
 {
-    template <typename state_t>
-        requires std::ranges::range<state_t>
-    auto
-    norm( state_t const& x )
-    {
-        auto zero = static_cast<decltype( *std::begin( x ) )>( 0. );
-        auto accu = std::accumulate( std::begin( x ),
-            std::end( x ),
-            zero,
-            []( auto const& acc, auto const& xi )
-            {
-                return acc + std::abs( xi ) * std::abs( xi );
-            } );
-        return std::sqrt( accu );
-    }
-
-    template <typename state_t>
-    auto
-    norm( state_t const& x )
-    {
-        return std::abs( x );
-    }
-
     template <typename value_t, typename state_t, typename func_t, typename jacobian_t, typename solver_t>
     state_t
     newton( func_t&& f, jacobian_t&& df, state_t const& x0, solver_t&& solver, value_t tol = 1e-10, std::size_t max_iter = 50 )
     {
         state_t xk       = x0;
-        value_t residual = norm( std::forward<func_t>( f )( xk ) );
+        value_t residual = ::ponio::detail::norm( std::forward<func_t>( f )( xk ) );
         std::size_t iter = 0;
 
         while ( iter < max_iter && residual > tol )
@@ -60,7 +37,7 @@ namespace ponio::runge_kutta::diagonal_implicit_runge_kutta
             auto increment = std::forward<solver_t>( solver )( std::forward<jacobian_t>( df )( xk ), -std::forward<func_t>( f )( xk ) );
 
             xk       = xk + increment;
-            residual = norm( std::forward<func_t>( f )( xk ) );
+            residual = ::ponio::detail::norm( std::forward<func_t>( f )( xk ) );
 
             iter += 1;
         }

--- a/ponio/include/ponio/splitting/strang.hpp
+++ b/ponio/include/ponio/splitting/strang.hpp
@@ -307,6 +307,78 @@ namespace ponio::splitting::strang
         }
 
         /**
+         * @brief estimate Lipschitz constant of problem \f$f\f$ at time \f$t^n\f$
+         *
+         * @param f  callable obect which represents the problem to solve
+         * @param tn time \f$t^n\f$ last time where solution is computed
+         * @param un computed solution \f$u^n\f$ à time \f$t^n\f$
+         * @param dt time step
+         * @return auto
+         *
+         * @details
+         */
+        template <typename Problem_t, typename state_t>
+        auto
+        lipschitz_constant_estimate( Problem_t& f, value_t tn, state_t& un, value_t dt )
+        {
+            static constexpr value_t a1 = 1.0;
+            static constexpr value_t b1 = 0.5;
+            static constexpr value_t c1 = 0.5;
+            static constexpr value_t a2 = c1;
+            static constexpr value_t b2 = 0.4;
+            static constexpr value_t c2 = 0.1;
+
+            auto local_error = [&]( value_t a, value_t b, value_t c )
+            {
+                state_t u_np1_a  = un;
+                state_t u_np1_bc = un;
+
+                // compute strang(tn, un, a*dt)
+                _call_inc( f, tn, u_np1_a, a * dt, 0. );
+
+                // compute strang(tn+c*dt, strang(tn, un, c*dt), b*dt )
+                _call_inc( f, tn, u_np1_bc, c * dt, 0. );
+                _call_inc( f, tn + c * dt, u_np1_bc, b * dt, 0. );
+
+                return ::ponio::detail::norm( u_np1_a - u_np1_bc );
+            };
+
+            // e1 = || S_{a1*dt}(un) - S_{b1*dt}(S_{c1*dt}(un)) ||
+            // e2 = || S_{a2*dt}(un) - S_{b2*dt}(S_{c2*dt}(un)) ||
+            auto e1 = local_error( a1, b1, c1 );
+            auto e2 = local_error( a2, b2, c2 );
+
+            // we have:
+            // || e1 - (a1**3 - b1**3)C0 dt**3 || <= w C0 c1**3 dt**3
+            // || e2 - (a2**3 - b2**3)C0 dt**3 || <= w C0 c2**3 dt**3
+            // so (if inequalities became equalities):
+            // c2**6 * ( e1 - (a1**3 - b1**3)C0 dt**3 )**2 ~= c1**6 * ( e2 - (a2**3 - b2**3)C0 dt**3 )**2
+            // then need to solve:
+            // alpha C0**2 + beta C0 + gamma = 0
+            // with:
+            // alpha = c2**6 * dt**6 * (a1**3 - b1**3)**2 - c1**6 * dt**6 * (a2**3 - b2**3)**2
+            // beta = -2 * ( c2**6 * dt**3 * (a1**3 - b1**3) * e1  + c1**6 * dt**3 * (a2**3 - b2**3) * e2 )
+            // gamma = c2**6 * e2**2 - c1**6 * e2**2
+            // we find positive root of this polynomial to compute C0
+
+            using ::ponio::detail::power;
+
+            value_t alpha = power<6>( c2 * dt ) * power<2>( power<3>( a1 ) - power<3>( b1 ) )
+                          - power<6>( c1 * dt ) * power<2>( power<3>( a2 ) - power<3>( b2 ) );
+            value_t beta = -2 * power<3>( dt )
+                         * ( power<6>( c2 ) * ( power<3>( a1 ) - power<3>( b1 ) ) * e1
+                             + power<6>( c1 ) * ( power<3>( a2 ) - power<3>( b2 ) ) * e2 );
+            value_t gamma = power<6>( c2 ) * power<2>( e1 ) - power<6>( c1 ) * power<2>( e2 );
+
+            value_t discriminent = 2. * beta * beta - alpha * gamma;
+            value_t C0           = ( -beta - std::sqrt( discriminent ) ) / ( 2. * alpha );
+
+            value_t omega = std::abs( e1 - ( power<3>( a1 ) - power<3>( b1 ) ) * C0 * power<3>( dt ) ) / ( C0 * power<3>( c1 * dt ) );
+
+            return std::make_pair( omega, C0 );
+        }
+
+        /**
          * @brief gets `iteration_info` object
          */
         auto&


### PR DESCRIPTION
<!-- Thank you for your contribution to ponio! -->
<!-- ༊彡 -->

<!-- Please check the following before submitting your PR -->
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [ ] This new PR is documented.
- [ ] This new PR is tested.

## Description
<!-- A clear and concise description of what you have done in this PR. -->

Add a function to estimate the value of Lipschitz constant to compute a shift of adaptive Strang method.

## Related issue
<!-- List the issues solved by this PR, if any. -->

## How has this been tested?
<!-- Give the list of files used to test this new implementation. -->

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/ponio/blob/master/ponio/doc/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
