### PR TITLE
fix: fix DIRK methods with samurai

### DIFF
--- a/ponio/include/ponio/samurai_linear_algebra.hpp
+++ b/ponio/include/ponio/samurai_linear_algebra.hpp
@@ -73,7 +73,8 @@ namespace ponio::linear_algebra
         solve( operator_t& op, state_t& u, rhs_t& rhs, std::size_t& n_eval )
         {
             auto solver = samurai::petsc::make_solver( op );
-            solver.solve( u, rhs );
+            auto _rhs   = static_cast<state_t>( rhs );
+            solver.solve( u, _rhs );
 
             if constexpr ( operator_t::cfg_t::scheme_type == samurai::SchemeType::NonLinear && has_Snes_method<decltype( solver )> )
             {


### PR DESCRIPTION
<!-- Thank you for your contribution to ponio! -->
<!-- ༊彡 -->

<!-- Please check the following before submitting your PR -->
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [x] This new PR is documented.
- [x] This new PR is tested.

## Description
<!-- A clear and concise description of what you have done in this PR. -->
Make a temporary field to store result of a `samurai::field_function` in `ponio::linear_algebra::operator_algebra<field_t>::solve` member function.

## Related issue
<!-- List the issues solved by this PR, if any. -->
Fail to compile because `u` and `rhs` are no more the same type.

## How has this been tested?
<!-- Give the list of files used to test this new implementation. -->

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/ponio/blob/master/ponio/doc/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
