### PR TITLE
feat: improve error norm for PIROCK

### DIFF
--- a/ponio/doc/source/api/algorithm/list_alg_pirock.rst
+++ b/ponio/doc/source/api/algorithm/list_alg_pirock.rst
@@ -117,6 +117,24 @@ ponio provides two computers for :math:`\alpha` and :math:`\beta` values.
    :project: ponio
    :members:
 
+With this functions you can initialize different kind of PIROCK method to solve your problem:
+
+The mainly diffusive case with :math:`\alpha=1` and :math:`\ell=2` (to get a ROCK2 method when reaction becomes null) use :cpp:func:`ponio::runge_kutta::pirock::pirock_a1` or :cpp:func:`ponio::runge_kutta::pirock::pirock` with a :cpp:class:`ponio::runge_kutta::pirock::alpha_fixed` object, you can also add a `Shampine's trick` caller to get adaptive time step method.
+
+.. code-block:: cpp
+
+    auto pirock = ponio::runge_kutta::pirock::pirock_a1();
+
+    // or
+
+    auto adaptive_pirock = ponio::runge_kutta::pirock::pirock<2, true>(
+      ponio::runge_kutta::pirock::alpha_fixed<double>( 1.0 ),
+      eigmax_computer,                                        // [](auto& f, double tn, auto& un, double dt, auto& du_work)
+      ponio::shampine_trick::shampine_trick<decltype( un )>() // Shampine's trick class
+    );
+
+The mainly reactive case with :math:`\beta=0` (or with less computational cost) you can also choose :math:`\ell = 1`, use :cpp:func:`ponio::runge_kutta::pirock::pirock_b0` or :cpp:func:`ponio::runge_kutta::pirock::pirock` with a :cpp:class:`ponio::runge_kutta::pirock::beta_0` object, you can also add a `Shampine's trick` caller to get adaptive time step method.
+
 
 PIROCK for reaction-diffusion problem
 -------------------------------------

--- a/ponio/examples/bz_2d_pirock.cpp
+++ b/ponio/examples/bz_2d_pirock.cpp
@@ -205,7 +205,7 @@ main( int argc, char** argv )
         eigmax_computer
     );
 
-    [[maybe_unused]] auto pirock_b0_st = ponio::runge_kutta::pirock::pirock<1, false>(
+    [[maybe_unused]] auto pirock_b0_st = ponio::runge_kutta::pirock::pirock<1, true>(
         ponio::runge_kutta::pirock::beta_0<double>(),
         eigmax_computer,
         ponio::shampine_trick::shampine_trick<decltype( y_ini )>()

--- a/ponio/examples/nagumo_pirock.cpp
+++ b/ponio/examples/nagumo_pirock.cpp
@@ -151,7 +151,7 @@ main( int argc, char** argv )
     };
 
     // time loop  -------------------------------------------------------------
-    auto pirock = ponio::runge_kutta::pirock::pirock<1>( ponio::runge_kutta::pirock::beta_0<double>(),
+    auto pirock = ponio::runge_kutta::pirock::pirock<1, true>( ponio::runge_kutta::pirock::beta_0<double>(),
         eigmax_computer,
         ponio::shampine_trick::shampine_trick<decltype( u_ini )>() );
 

--- a/ponio/include/ponio/linear_algebra.hpp
+++ b/ponio/include/ponio/linear_algebra.hpp
@@ -114,7 +114,7 @@ namespace ponio
     value_t
     norm_error( state_t const& x, state_t const& y, state_t const& z, value_t a_tol, value_t r_tol )
     {
-        return detail::power<2>( x / ( a_tol + r_tol * std::max( std::abs( y ), std::abs( z ) ) ) );
+        return std::abs( x / ( a_tol + r_tol * std::max( std::abs( y ), std::abs( z ) ) ) );
     }
 
     /**
@@ -135,13 +135,15 @@ namespace ponio
         auto it_y = std::begin( y );
         auto it_z = std::begin( z );
 
-        return std::accumulate( std::begin( x ),
-            std::end( x ),
-            static_cast<value_t>( 0. ),
-            [&]( auto const& acc, auto const& x_i )
-            {
-                return acc + detail::power<2>( x_i / ( a_tol + r_tol * std::max( std::abs( *it_y++ ), std::abs( *it_z++ ) ) ) );
-            } );
+        return std::sqrt( 1. / ( std::size( x ) )
+                          * std::accumulate( std::begin( x ),
+                              std::end( x ),
+                              static_cast<value_t>( 0. ),
+                              [&]( auto const& acc, auto const& x_i )
+                              {
+                                  return acc
+                                       + detail::power<2>( x_i / ( a_tol + r_tol * std::max( std::abs( *it_y++ ), std::abs( *it_z++ ) ) ) );
+                              } ) );
     }
 
 } // namespace ponio

--- a/ponio/include/ponio/linear_algebra.hpp
+++ b/ponio/include/ponio/linear_algebra.hpp
@@ -103,47 +103,43 @@ namespace ponio::shampine_trick
         static constexpr bool dependent_false = false;
 
         static_assert( dependent_false<state_t>, "non implemented Shampine's trick structure for this type" );
+
+        template <typename value_t>
+        value_t
+        norm_error( state_t const& x, state_t const& y, state_t const& z, value_t a_tol, value_t r_tol )
+        {
+            return std::abs( x / ( a_tol + r_tol * std::max( std::abs( y ), std::abs( z ) ) ) );
+        }
+
+        // /**
+        //  * @brief return a error norm given by: \f$$\sum_i \left(\frac{x_i}{a_{tol} + r_{tol}\max(|y_i|, |z_i|)}\right)^2\f$$
+        //  *
+        //  * @tparam value_t type of tolerances
+        //  * @tparam state_t type of vectors \f$x\f$, \f$y\f$ and \f$z\f$
+        //  * @param x mainly the estimate error
+        //  * @param y mainly the solution at time \f$t^n\f$
+        //  * @param z mainly the estimation of solution at time \f$t^{n+1}\f$
+        //  * @param a_tol absolute tolerance
+        //  * @param r_tol relative tolerance
+        //  */
+        // template <typename state_t, typename value_t>
+        // value_t
+        // norm_error( state_t const& x, state_t const& y, state_t const& z, value_t a_tol, value_t r_tol )
+        // {
+        //     auto it_y = std::begin( y );
+        //     auto it_z = std::begin( z );
+
+        //     return std::sqrt( 1. / ( std::size( x ) )
+        //                       * std::accumulate( std::begin( x ),
+        //                           std::end( x ),
+        //                           static_cast<value_t>( 0. ),
+        //                           [&]( auto const& acc, auto const& x_i )
+        //                           {
+        //                               return acc
+        //                                    + detail::power<2>( x_i / ( a_tol + r_tol * std::max( std::abs( *it_y++ ), std::abs( *it_z++ )
+        //                                    ) )
+        //                                    );
+        //                           } ) );
+        // }
     };
 } // namespace ponio::shampine_trick
-
-namespace ponio
-{
-
-    template <typename value_t, typename state_t>
-        requires std::floating_point<state_t>
-    value_t
-    norm_error( state_t const& x, state_t const& y, state_t const& z, value_t a_tol, value_t r_tol )
-    {
-        return std::abs( x / ( a_tol + r_tol * std::max( std::abs( y ), std::abs( z ) ) ) );
-    }
-
-    /**
-     * @brief return a error norm given by: \f$$\sum_i \left(\frac{x_i}{a_{tol} + r_{tol}\max(|y_i|, |z_i|)}\right)^2\f$$
-     *
-     * @tparam value_t type of tolerances
-     * @tparam state_t type of vectors \f$x\f$, \f$y\f$ and \f$z\f$
-     * @param x mainly the estimate error
-     * @param y mainly the solution at time \f$t^n\f$
-     * @param z mainly the estimation of solution at time \f$t^{n+1}\f$
-     * @param a_tol absolute tolerance
-     * @param r_tol relative tolerance
-     */
-    template <typename value_t, typename state_t>
-    value_t
-    norm_error( state_t const& x, state_t const& y, state_t const& z, value_t a_tol, value_t r_tol )
-    {
-        auto it_y = std::begin( y );
-        auto it_z = std::begin( z );
-
-        return std::sqrt( 1. / ( std::size( x ) )
-                          * std::accumulate( std::begin( x ),
-                              std::end( x ),
-                              static_cast<value_t>( 0. ),
-                              [&]( auto const& acc, auto const& x_i )
-                              {
-                                  return acc
-                                       + detail::power<2>( x_i / ( a_tol + r_tol * std::max( std::abs( *it_y++ ), std::abs( *it_z++ ) ) ) );
-                              } ) );
-    }
-
-} // namespace ponio

--- a/ponio/include/ponio/linear_algebra.hpp
+++ b/ponio/include/ponio/linear_algebra.hpp
@@ -8,6 +8,8 @@
 #include <concepts>
 #include <cstddef>
 
+#include "detail.hpp"
+
 namespace ponio::linear_algebra
 {
 
@@ -103,3 +105,43 @@ namespace ponio::shampine_trick
         static_assert( dependent_false<state_t>, "non implemented Shampine's trick structure for this type" );
     };
 } // namespace ponio::shampine_trick
+
+namespace ponio
+{
+
+    template <typename value_t, typename state_t>
+        requires std::floating_point<state_t>
+    value_t
+    norm_error( state_t const& x, state_t const& y, state_t const& z, value_t a_tol, value_t r_tol )
+    {
+        return detail::power<2>( x / ( a_tol + r_tol * std::max( std::abs( y ), std::abs( z ) ) ) );
+    }
+
+    /**
+     * @brief return a error norm given by: \f$$\sum_i \left(\frac{x_i}{a_{tol} + r_{tol}\max(|y_i|, |z_i|)}\right)^2\f$$
+     *
+     * @tparam value_t type of tolerances
+     * @tparam state_t type of vectors \f$x\f$, \f$y\f$ and \f$z\f$
+     * @param x mainly the estimate error
+     * @param y mainly the solution at time \f$t^n\f$
+     * @param z mainly the estimation of solution at time \f$t^{n+1}\f$
+     * @param a_tol absolute tolerance
+     * @param r_tol relative tolerance
+     */
+    template <typename value_t, typename state_t>
+    value_t
+    norm_error( state_t const& x, state_t const& y, state_t const& z, value_t a_tol, value_t r_tol )
+    {
+        auto it_y = std::begin( y );
+        auto it_z = std::begin( z );
+
+        return std::accumulate( std::begin( x ),
+            std::end( x ),
+            static_cast<value_t>( 0. ),
+            [&]( auto const& acc, auto const& x_i )
+            {
+                return acc + detail::power<2>( x_i / ( a_tol + r_tol * std::max( std::abs( *it_y++ ), std::abs( *it_z++ ) ) ) );
+            } );
+    }
+
+} // namespace ponio

--- a/ponio/include/ponio/runge_kutta/pirock.hpp
+++ b/ponio/include/ponio/runge_kutta/pirock.hpp
@@ -21,6 +21,7 @@
 #include "../iteration_info.hpp"
 #include "../linear_algebra.hpp"
 #include "../ponio_config.hpp"
+#include "../samurai_linear_algebra.hpp"
 #include "../stage.hpp"
 #include "dirk.hpp"
 #include "rock.hpp"

--- a/ponio/include/ponio/runge_kutta/pirock.hpp
+++ b/ponio/include/ponio/runge_kutta/pirock.hpp
@@ -1214,9 +1214,21 @@ namespace ponio::runge_kutta::pirock
                     };
 
                     // TODO: this couple of lines works only with samurai (because of err_D.array())
-                    value_t err_R_scalar = norm_error( err_R, un, u_np1, _info.absolute_tolerance, _info.relative_tolerance );
-                    value_t err_D_scalar = norm_error( err_D, un, u_np1, _info.absolute_tolerance, _info.relative_tolerance );
-                    value_t err_A_scalar = norm_error( err_A, un, u_np1, _info.absolute_tolerance, _info.relative_tolerance );
+                    value_t err_R_scalar = shampine_trick_caller.norm_error( err_R,
+                        un,
+                        u_np1,
+                        _info.absolute_tolerance,
+                        _info.relative_tolerance );
+                    value_t err_D_scalar = shampine_trick_caller.norm_error( err_D,
+                        un,
+                        u_np1,
+                        _info.absolute_tolerance,
+                        _info.relative_tolerance );
+                    value_t err_A_scalar = shampine_trick_caller.norm_error( err_A,
+                        un,
+                        u_np1,
+                        _info.absolute_tolerance,
+                        _info.relative_tolerance );
 
                     _info.error   = std::max( err_D_scalar, err_R_scalar, std::pow( err_A_scalar, 2. / 3. ) );
                     _info.success = _info.error < 1.0;

--- a/ponio/include/ponio/runge_kutta/pirock.hpp
+++ b/ponio/include/ponio/runge_kutta/pirock.hpp
@@ -21,7 +21,6 @@
 #include "../iteration_info.hpp"
 #include "../linear_algebra.hpp"
 #include "../ponio_config.hpp"
-#include "../samurai_linear_algebra.hpp"
 #include "../stage.hpp"
 #include "dirk.hpp"
 #include "rock.hpp"
@@ -528,8 +527,16 @@ namespace ponio::runge_kutta::pirock
                     //     static_cast<value_t>( 0. ),
                     //     accumulator_error_gen( un.array(), u_np1.array(), _info.absolute_tolerance, _info.relative_tolerance ) );
 
-                    value_t err_R_scalar = norm_error( err_R, un, u_np1, _info.absolute_tolerance, _info.relative_tolerance );
-                    value_t err_D_scalar = norm_error( err_D, un, u_np1, _info.absolute_tolerance, _info.relative_tolerance );
+                    value_t err_R_scalar = shampine_trick_caller.norm_error( err_R,
+                        un,
+                        u_np1,
+                        _info.absolute_tolerance,
+                        _info.relative_tolerance );
+                    value_t err_D_scalar = shampine_trick_caller.norm_error( err_D,
+                        un,
+                        u_np1,
+                        _info.absolute_tolerance,
+                        _info.relative_tolerance );
 
                     _info.error   = std::max( err_D_scalar, err_R_scalar );
                     _info.success = _info.error < 1.0;

--- a/ponio/include/ponio/runge_kutta/pirock.hpp
+++ b/ponio/include/ponio/runge_kutta/pirock.hpp
@@ -508,24 +508,27 @@ namespace ponio::runge_kutta::pirock
 
                     u_np1 = us_s - err_D + 0.5 * dt * fi_tmp + 0.5 * dt * f_tmp + dt / ( 2. - 4. * gamma ) * shampine_element;
 
-                    auto accumulator_error_gen = []( auto const& yn, auto const& ynp1, value_t a_tol, value_t r_tol )
-                    {
-                        return [=, it_yn = yn.begin(), it_ynp1 = ynp1.begin()]( value_t const& acc, value_t const err_i ) mutable
-                        {
-                            using namespace std;
-                            return acc + detail::power<2>( err_i / ( a_tol + r_tol * max( abs( *it_yn++ ), abs( *it_ynp1++ ) ) ) );
-                        };
-                    };
+                    // auto accumulator_error_gen = []( auto const& yn, auto const& ynp1, value_t a_tol, value_t r_tol )
+                    // {
+                    //     return [=, it_yn = yn.begin(), it_ynp1 = ynp1.begin()]( value_t const& acc, value_t const err_i ) mutable
+                    //     {
+                    //         using namespace std;
+                    //         return acc + detail::power<2>( err_i / ( a_tol + r_tol * max( abs( *it_yn++ ), abs( *it_ynp1++ ) ) ) );
+                    //     };
+                    // };
 
                     // TODO: this couple of lines works only with samurai (because of err_D.array())
-                    value_t err_R_scalar = std::accumulate( err_R.array().begin(),
-                        err_R.array().end(),
-                        static_cast<value_t>( 0. ),
-                        accumulator_error_gen( un.array(), u_np1.array(), _info.absolute_tolerance, _info.relative_tolerance ) );
-                    value_t err_D_scalar = std::accumulate( err_D.array().begin(),
-                        err_D.array().end(),
-                        static_cast<value_t>( 0. ),
-                        accumulator_error_gen( un.array(), u_np1.array(), _info.absolute_tolerance, _info.relative_tolerance ) );
+                    // value_t err_R_scalar = std::accumulate( err_R.array().begin(),
+                    //     err_R.array().end(),
+                    //     static_cast<value_t>( 0. ),
+                    //     accumulator_error_gen( un.array(), u_np1.array(), _info.absolute_tolerance, _info.relative_tolerance ) );
+                    // value_t err_D_scalar = std::accumulate( err_D.array().begin(),
+                    //     err_D.array().end(),
+                    //     static_cast<value_t>( 0. ),
+                    //     accumulator_error_gen( un.array(), u_np1.array(), _info.absolute_tolerance, _info.relative_tolerance ) );
+
+                    value_t err_R_scalar = norm_error( err_R, un, u_np1, _info.absolute_tolerance, _info.relative_tolerance );
+                    value_t err_D_scalar = norm_error( err_D, un, u_np1, _info.absolute_tolerance, _info.relative_tolerance );
 
                     _info.error   = std::max( err_D_scalar, err_R_scalar );
                     _info.success = _info.error < 1.0;
@@ -1203,18 +1206,9 @@ namespace ponio::runge_kutta::pirock
                     };
 
                     // TODO: this couple of lines works only with samurai (because of err_D.array())
-                    value_t err_R_scalar = std::accumulate( err_R.array().begin(),
-                        err_R.array().end(),
-                        static_cast<value_t>( 0. ),
-                        accumulator_error_gen( un.array(), u_np1.array(), _info.absolute_tolerance, _info.relative_tolerance ) );
-                    value_t err_D_scalar = std::accumulate( err_D.array().begin(),
-                        err_D.array().end(),
-                        static_cast<value_t>( 0. ),
-                        accumulator_error_gen( un.array(), u_np1.array(), _info.absolute_tolerance, _info.relative_tolerance ) );
-                    value_t err_A_scalar = std::accumulate( err_A.array().begin(),
-                        err_A.array().end(),
-                        static_cast<value_t>( 0. ),
-                        accumulator_error_gen( un.array(), u_np1.array(), _info.absolute_tolerance, _info.relative_tolerance ) );
+                    value_t err_R_scalar = norm_error( err_R, un, u_np1, _info.absolute_tolerance, _info.relative_tolerance );
+                    value_t err_D_scalar = norm_error( err_D, un, u_np1, _info.absolute_tolerance, _info.relative_tolerance );
+                    value_t err_A_scalar = norm_error( err_A, un, u_np1, _info.absolute_tolerance, _info.relative_tolerance );
 
                     _info.error   = std::max( err_D_scalar, err_R_scalar, std::pow( err_A_scalar, 2. / 3. ) );
                     _info.success = _info.error < 1.0;

--- a/ponio/include/ponio/samurai_linear_algebra.hpp
+++ b/ponio/include/ponio/samurai_linear_algebra.hpp
@@ -205,14 +205,41 @@ namespace ponio
     value_t
     norm_error( state_t const& x, state_t const& y, state_t const& z, value_t a_tol, value_t r_tol )
     {
-        value_t err = 0.;
+        std::array<value_t, state_t::n_comp> sc;
+        sc.fill( static_cast<value_t>( 0. ) );
+        std::array<value_t, state_t::n_comp> err_comp;
+        err_comp.fill( static_cast<value_t>( 0. ) );
+        auto volume = static_cast<value_t>( 0. );
 
         samurai::for_each_cell( x.mesh(),
             [&]( auto& cell )
             {
-                err += xt::sum( xt::pow( x[cell] / ( a_tol + r_tol * xt::maximum( xt::abs( y[cell] ), xt::abs( z[cell] ) ) ), 2 ) )[0]
-                     * cell.length;
+                volume += detail::power<state_t::dim>( cell.length );
+
+                for ( std::size_t i = 0ul; i < state_t::n_comp; ++i )
+                {
+                    value_t y_i = samurai::field_value( y, cell, i );
+                    value_t z_i = samurai::field_value( z, cell, i );
+
+                    value_t tmp_i = std::max( std::abs( y_i ), std::abs( z_i ) );
+
+                    sc[i] = std::max( tmp_i, sc[i] );
+                }
             } );
+
+        samurai::for_each_cell( x.mesh(),
+            [&]( auto& cell )
+            {
+                for ( std::size_t i = 0ul; i < state_t::n_comp; ++i )
+                {
+                    value_t x_i = samurai::field_value( x, cell, i );
+
+                    err_comp[i] += detail::power<2>( x_i / ( a_tol + r_tol * sc[i] ) ) * cell.length;
+                }
+            } );
+
+        auto err = std::sqrt( ( 1. / ( volume * static_cast<value_t>( state_t::n_comp ) ) )
+                              * std::accumulate( err_comp.begin(), err_comp.end(), static_cast<value_t>( 0. ) ) );
 
         return err;
     }

--- a/ponio/include/ponio/samurai_linear_algebra.hpp
+++ b/ponio/include/ponio/samurai_linear_algebra.hpp
@@ -6,6 +6,7 @@
 
 #include <cassert>
 
+#include "detail.hpp"
 #include "linear_algebra.hpp"
 
 #if __has_include( <samurai/schemes/fv.hpp> )
@@ -185,3 +186,35 @@ namespace ponio::shampine_trick
     };
 
 } // namespace ponio::shampine_trick
+
+namespace ponio
+{
+    /**
+     * @brief return a error norm given by: \f$$\sum_i \left(\frac{x_i}{a_{tol} + r_{tol}\max(|y_i|, |z_i|)}\right)^2\Delta x_i\f$$
+     *
+     * @tparam value_t type of tolerances
+     * @tparam state_t type of vectors \f$x\f$, \f$y\f$ and \f$z\f$
+     * @param x mainly the estimate error
+     * @param y mainly the solution at time \f$t^n\f$
+     * @param z mainly the estimation of solution at time \f$t^{n+1}\f$
+     * @param a_tol absolute tolerance
+     * @param r_tol relative tolerance
+     */
+    template <typename value_t, typename state_t>
+        requires ::ponio_samurai::is_samurai_field<state_t>
+    value_t
+    norm_error( state_t const& x, state_t const& y, state_t const& z, value_t a_tol, value_t r_tol )
+    {
+        value_t err = 0.;
+
+        samurai::for_each_cell( x.mesh(),
+            [&]( auto& cell )
+            {
+                err += xt::sum( xt::pow( x[cell] / ( a_tol + r_tol * xt::maximum( xt::abs( y[cell] ), xt::abs( z[cell] ) ) ), 2 ) )[0]
+                     * cell.length;
+            } );
+
+        return err;
+    }
+
+} // namespace ponio

--- a/ponio/include/ponio/samurai_linear_algebra.hpp
+++ b/ponio/include/ponio/samurai_linear_algebra.hpp
@@ -187,6 +187,16 @@ namespace ponio::shampine_trick
         /**
          * @brief return a error norm given by: \f$$\sum_i \left(\frac{x_i}{a_{tol} + r_{tol}\max(|y_i|, |z_i|)}\right)^2\Delta x_i\f$$
          *
+         * This function computes a error norm for a samurai field (ScalarField or VectorField).
+         *
+         * First step is to compute volume of domain \f$|\Omega|=\sum_k \Delta x_k ^d\f$ where \f$d\f$ is the dimension of field, and
+         * normalization coefficients \f$sc_i = \max_k(|y_{i,k}|, |z_{i,k}|)\f$ for composant \f$i\f$i in cell \f$k\f$.
+         *
+         * Next we compute an error foreach composant : \f$err_i = \sum_k\left(\frac{x_{i,k}}{a_{tol} + r_{tol}sc_i}\Delta x_k\right)^2\f$
+         * where \f$x_{i,k}\f$ is the value of composant \f$i\f$ in cell \f$k\f$.
+         *
+         * Then the computed error is given by \f$err = \frac{1}{|\omega| N_{comp}}\sum_i err_i\f$.
+         *
          * @tparam value_t type of tolerances
          * @tparam state_t type of vectors \f$x\f$, \f$y\f$ and \f$z\f$
          * @param x mainly the estimate error

--- a/ponio/include/ponio/samurai_linear_algebra.hpp
+++ b/ponio/include/ponio/samurai_linear_algebra.hpp
@@ -183,65 +183,59 @@ namespace ponio::shampine_trick
             KSPDestroy( &ksp );
             MatDestroy( &J_R );
         }
+
+        /**
+         * @brief return a error norm given by: \f$$\sum_i \left(\frac{x_i}{a_{tol} + r_{tol}\max(|y_i|, |z_i|)}\right)^2\Delta x_i\f$$
+         *
+         * @tparam value_t type of tolerances
+         * @tparam state_t type of vectors \f$x\f$, \f$y\f$ and \f$z\f$
+         * @param x mainly the estimate error
+         * @param y mainly the solution at time \f$t^n\f$
+         * @param z mainly the estimation of solution at time \f$t^{n+1}\f$
+         * @param a_tol absolute tolerance
+         * @param r_tol relative tolerance
+         */
+        value_t
+        norm_error( field_t const& x, field_t const& y, field_t const& z, value_t a_tol, value_t r_tol )
+        {
+            std::array<value_t, field_t::n_comp> sc;
+            sc.fill( static_cast<value_t>( 0. ) );
+            std::array<value_t, field_t::n_comp> err_comp;
+            err_comp.fill( static_cast<value_t>( 0. ) );
+            auto volume = static_cast<value_t>( 0. );
+
+            samurai::for_each_cell( x.mesh(),
+                [&]( auto& cell )
+                {
+                    volume += detail::power<field_t::dim>( cell.length );
+
+                    for ( std::size_t i = 0ul; i < field_t::n_comp; ++i )
+                    {
+                        value_t y_i = samurai::field_value( y, cell, i );
+                        value_t z_i = samurai::field_value( z, cell, i );
+
+                        value_t tmp_i = std::max( std::abs( y_i ), std::abs( z_i ) );
+
+                        sc[i] = std::max( tmp_i, sc[i] );
+                    }
+                } );
+
+            samurai::for_each_cell( x.mesh(),
+                [&]( auto& cell )
+                {
+                    for ( std::size_t i = 0ul; i < field_t::n_comp; ++i )
+                    {
+                        value_t x_i = samurai::field_value( x, cell, i );
+
+                        err_comp[i] += detail::power<2>( x_i / ( a_tol + r_tol * sc[i] ) ) * cell.length;
+                    }
+                } );
+
+            auto err = std::sqrt( ( 1. / ( volume * static_cast<value_t>( field_t::n_comp ) ) )
+                                  * std::accumulate( err_comp.begin(), err_comp.end(), static_cast<value_t>( 0. ) ) );
+
+            return err;
+        }
     };
 
 } // namespace ponio::shampine_trick
-
-namespace ponio
-{
-    /**
-     * @brief return a error norm given by: \f$$\sum_i \left(\frac{x_i}{a_{tol} + r_{tol}\max(|y_i|, |z_i|)}\right)^2\Delta x_i\f$$
-     *
-     * @tparam value_t type of tolerances
-     * @tparam state_t type of vectors \f$x\f$, \f$y\f$ and \f$z\f$
-     * @param x mainly the estimate error
-     * @param y mainly the solution at time \f$t^n\f$
-     * @param z mainly the estimation of solution at time \f$t^{n+1}\f$
-     * @param a_tol absolute tolerance
-     * @param r_tol relative tolerance
-     */
-    template <typename value_t, typename state_t>
-        requires ::ponio_samurai::is_samurai_field<state_t>
-    value_t
-    norm_error( state_t const& x, state_t const& y, state_t const& z, value_t a_tol, value_t r_tol )
-    {
-        std::array<value_t, state_t::n_comp> sc;
-        sc.fill( static_cast<value_t>( 0. ) );
-        std::array<value_t, state_t::n_comp> err_comp;
-        err_comp.fill( static_cast<value_t>( 0. ) );
-        auto volume = static_cast<value_t>( 0. );
-
-        samurai::for_each_cell( x.mesh(),
-            [&]( auto& cell )
-            {
-                volume += detail::power<state_t::dim>( cell.length );
-
-                for ( std::size_t i = 0ul; i < state_t::n_comp; ++i )
-                {
-                    value_t y_i = samurai::field_value( y, cell, i );
-                    value_t z_i = samurai::field_value( z, cell, i );
-
-                    value_t tmp_i = std::max( std::abs( y_i ), std::abs( z_i ) );
-
-                    sc[i] = std::max( tmp_i, sc[i] );
-                }
-            } );
-
-        samurai::for_each_cell( x.mesh(),
-            [&]( auto& cell )
-            {
-                for ( std::size_t i = 0ul; i < state_t::n_comp; ++i )
-                {
-                    value_t x_i = samurai::field_value( x, cell, i );
-
-                    err_comp[i] += detail::power<2>( x_i / ( a_tol + r_tol * sc[i] ) ) * cell.length;
-                }
-            } );
-
-        auto err = std::sqrt( ( 1. / ( volume * static_cast<value_t>( state_t::n_comp ) ) )
-                              * std::accumulate( err_comp.begin(), err_comp.end(), static_cast<value_t>( 0. ) ) );
-
-        return err;
-    }
-
-} // namespace ponio

--- a/ponio/template/tpl_doc_algorithms.rst
+++ b/ponio/template/tpl_doc_algorithms.rst
@@ -534,9 +534,9 @@ Following functions are useful for to build a PIROCK method with :math:`\ell=1` 
 
 With this functions you can initialize different kind of PIROCK method to solve your problem:
 
-The mainly diffusive case with :math:`\alpha=1` (to get a ROCK2 method when reaction becomes null) use :cpp:func:`ponio::runge_kutta::pirock::pirock_a1` or :cpp:func:`ponio::runge_kutta::pirock::pirock` with a :cpp:class:`ponio::runge_kutta::pirock::alpha_fixed` object, you can also add a `Shampine's trick` caller to get adaptive time step method.
+The mainly diffusive case with :math:`\alpha=1` and :math:`\ell=2` (to get a ROCK2 method when reaction becomes null) use :cpp:func:`ponio::runge_kutta::pirock::pirock_a1` or :cpp:func:`ponio::runge_kutta::pirock::pirock` with a :cpp:class:`ponio::runge_kutta::pirock::alpha_fixed` object, you can also add a `Shampine's trick` caller to get adaptive time step method.
 
-.. cpp::
+.. code-block:: cpp
 
     auto pirock = ponio::runge_kutta::pirock::pirock_a1();
 
@@ -550,7 +550,7 @@ The mainly diffusive case with :math:`\alpha=1` (to get a ROCK2 method when reac
 
 The mainly reactive case with :math:`\beta=0` (or with less computational cost) you can also choose :math:`\ell = 1`, use :cpp:func:`ponio::runge_kutta::pirock::pirock_b0` or :cpp:func:`ponio::runge_kutta::pirock::pirock` with a :cpp:class:`ponio::runge_kutta::pirock::beta_0` object, you can also add a `Shampine's trick` caller to get adaptive time step method.
 
-.. cpp::
+.. code-block:: cpp
 
     auto pirock = ponio::runge_kutta::pirock::pirock_b0();
 

--- a/ponio/template/tpl_doc_algorithms.rst
+++ b/ponio/template/tpl_doc_algorithms.rst
@@ -534,8 +534,33 @@ Following functions are useful for to build a PIROCK method with :math:`\ell=1` 
 
 With this functions you can initialize different kind of PIROCK method to solve your problem:
 
-* The mainly diffusive case with :math:`\alpha=1` (to get a ROCK2 method when reaction becomes null) use :cpp:func:`ponio::runge_kutta::pirock::pirock_a1` or :cpp:func:`ponio::runge_kutta::pirock::pirock` with a :cpp:class:`ponio::runge_kutta::pirock::alpha_fixed` object, you can also add a `Shampine's trick` caller to get adaptive time step method.
-* The mainly reactive case with :math:`\beta=0` (or with less computational cost) you can also choose :math:`\ell = 1`, use :cpp:func:`ponio::runge_kutta::pirock::pirock_b0` or :cpp:func:`ponio::runge_kutta::pirock::pirock` with a :cpp:class:`ponio::runge_kutta::pirock::beta_0` object, you can also add a `Shampine's trick` caller to get adaptive time step method.
+The mainly diffusive case with :math:`\alpha=1` (to get a ROCK2 method when reaction becomes null) use :cpp:func:`ponio::runge_kutta::pirock::pirock_a1` or :cpp:func:`ponio::runge_kutta::pirock::pirock` with a :cpp:class:`ponio::runge_kutta::pirock::alpha_fixed` object, you can also add a `Shampine's trick` caller to get adaptive time step method.
+
+.. cpp::
+
+    auto pirock = ponio::runge_kutta::pirock::pirock_a1();
+
+    // or
+
+    auto adaptive_pirock = ponio::runge_kutta::pirock::pirock<2, true>(
+      ponio::runge_kutta::pirock::alpha_fixed<double>( 1.0 ),
+      eigmax_computer,                                        // [](auto& f, double tn, auto& un, double dt, auto& du_work)
+      ponio::shampine_trick::shampine_trick<decltype( un )>() // Shampine's trick class
+    );
+
+The mainly reactive case with :math:`\beta=0` (or with less computational cost) you can also choose :math:`\ell = 1`, use :cpp:func:`ponio::runge_kutta::pirock::pirock_b0` or :cpp:func:`ponio::runge_kutta::pirock::pirock` with a :cpp:class:`ponio::runge_kutta::pirock::beta_0` object, you can also add a `Shampine's trick` caller to get adaptive time step method.
+
+.. cpp::
+
+    auto pirock = ponio::runge_kutta::pirock::pirock_b0();
+
+    // or
+
+    auto adaptive_pirock = ponio::runge_kutta::pirock::pirock<1, true>(
+      ponio::runge_kutta::pirock::beta_0<double>(),
+      eigmax_computer,                                        // [](auto& f, double tn, auto& un, double dt, auto& du_work)
+      ponio::shampine_trick::shampine_trick<decltype( un )>() // Shampine's trick class
+    );
 
 
 PIROCK for reaction-diffusion-advection problem

--- a/ponio/template/tpl_doc_algorithms.rst
+++ b/ponio/template/tpl_doc_algorithms.rst
@@ -532,6 +532,11 @@ Following functions are useful for to build a PIROCK method with :math:`\ell=1` 
 .. doxygenfunction:: ponio::runge_kutta::pirock::pirock_b0()
   :project: ponio
 
+With this functions you can initialize different kind of PIROCK method to solve your problem:
+
+* The mainly diffusive case with :math:`\alpha=1` (to get a ROCK2 method when reaction becomes null) use :cpp:func:`ponio::runge_kutta::pirock::pirock_a1` or :cpp:func:`ponio::runge_kutta::pirock::pirock` with a :cpp:class:`ponio::runge_kutta::pirock::alpha_fixed` object, you can also add a `Shampine's trick` caller to get adaptive time step method.
+* The mainly reactive case with :math:`\beta=0` (or with less computational cost) you can also choose :math:`\ell = 1`, use :cpp:func:`ponio::runge_kutta::pirock::pirock_b0` or :cpp:func:`ponio::runge_kutta::pirock::pirock` with a :cpp:class:`ponio::runge_kutta::pirock::beta_0` object, you can also add a `Shampine's trick` caller to get adaptive time step method.
+
 
 PIROCK for reaction-diffusion-advection problem
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
<!-- Thank you for your contribution to ponio! -->
<!-- ༊彡 -->

<!-- Please check the following before submitting your PR -->
- [x] I have installed [pre-commit](https://pre-commit.com/) locally and use it to validate my commits.
- [x] The PR title follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
      Available tags: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'
- [ ] This new PR is documented.
- [ ] This new PR is tested.

## Description
<!-- A clear and concise description of what you have done in this PR. -->
Improve error norm for adaptive time step method for PIROCK, for adaptive mesh refinement.

## Related issue
<!-- List the issues solved by this PR, if any. -->

## How has this been tested?
<!-- Give the list of files used to test this new implementation. -->

## Code of Conduct
By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/hpc-maths/ponio/blob/master/ponio/doc/CODE_OF_CONDUCT.md)
- [x] I agree to follow this project's Code of Conduct
